### PR TITLE
fix: bot-worker startup race leaves Slack bot permanently disconnected

### DIFF
--- a/api/src/bot_worker/redis_state.py
+++ b/api/src/bot_worker/redis_state.py
@@ -355,6 +355,14 @@ class BotRedisState:
 
         return events
 
+    def get_latest_event_id(self) -> str:
+        """Return the ID of the most-recent event in the stream, or '0' if empty."""
+        result = self.redis.xrevrange(self.KEY_BOT_EVENTS, "+", "-", count=1)
+        if result:
+            msg_id, _ = result[0]
+            return msg_id if isinstance(msg_id, str) else msg_id.decode()
+        return "0"
+
     def trim_bot_events(self, max_len: int = 10000) -> None:
         """Trim the event stream to prevent unbounded growth.
 

--- a/api/src/bot_worker/worker.py
+++ b/api/src/bot_worker/worker.py
@@ -197,6 +197,10 @@ class BotWorker:
         # Claim and start bots assigned to this worker
         await self._claim_assigned_bots()
 
+        # Snapshot the current stream tail so the event listener only processes
+        # events that arrive AFTER this pod starts — not historical replays.
+        self._last_event_id = self.redis_state.get_latest_event_id()
+
         # Start background tasks
         self._heartbeat_task = asyncio.create_task(self._heartbeat_loop())
         self._event_listener_task = asyncio.create_task(self._event_listener_loop())
@@ -772,7 +776,10 @@ class BotWorker:
                     except (asyncio.CancelledError, Exception):
                         pass
                 handler = self._slack_handlers.pop(bot_id)
-                await handler.close_async()
+                try:
+                    await asyncio.wait_for(handler.close_async(), timeout=5)
+                except (TimeoutError, Exception):
+                    pass
 
             elif bot_type == "telegram" and bot_id in self._telegram_apps:
                 app = self._telegram_apps.pop(bot_id)
@@ -936,7 +943,7 @@ class BotWorker:
                 logger.warning(f"Unknown command: {command}")
 
     async def _dead_worker_check_loop(self) -> None:
-        """Periodically check for dead workers and claim their bots."""
+        """Periodically check for dead workers and ensure our assigned bots are running."""
         while not self._is_shutting_down:
             try:
                 # Check every 15 seconds
@@ -955,8 +962,10 @@ class BotWorker:
                     # Rebuild ring from scratch so the current worker is always present
                     await self._rebuild_hash_ring()
 
-                    # Claim bots that should now be ours
-                    await self._claim_orphaned_bots()
+                # Always self-heal: start any bots that should be ours but stopped.
+                # This handles bots lost to dead-worker redistribution, event-driven
+                # stop without a matching activate, or transient startup failures.
+                await self._claim_orphaned_bots()
 
             except Exception as e:
                 logger.error(f"Dead worker check error: {e}")

--- a/api/src/bot_worker/worker.py
+++ b/api/src/bot_worker/worker.py
@@ -954,17 +954,15 @@ class BotWorker:
 
                 if dead_workers:
                     logger.info(f"Found {len(dead_workers)} dead workers: {dead_workers}")
-
-                    # Unregister dead workers from Redis
                     for worker_id in dead_workers:
                         self.redis_state.unregister_worker(worker_id)
 
-                    # Rebuild ring from scratch so the current worker is always present
-                    await self._rebuild_hash_ring()
+                # Rebuild ring every cycle — picks up workers that gracefully
+                # unregistered without being detected as dead (e.g. old pod during
+                # rolling deploy), not only when a dead worker is detected.
+                await self._rebuild_hash_ring()
 
-                # Always self-heal: start any bots that should be ours but stopped.
-                # This handles bots lost to dead-worker redistribution, event-driven
-                # stop without a matching activate, or transient startup failures.
+                # Self-heal: start any bots that should be ours but aren't running.
                 await self._claim_orphaned_bots()
 
             except Exception as e:


### PR DESCRIPTION
## Summary

- **Historical event replay**: event listener started from `last_id="0"`, replaying old ACTIVATE/DEACTIVATE events from Redis stream immediately at startup, causing start→stop cycles (visible in pod logs at 16:01:43–45). Fix: snapshot stream tail after `_claim_assigned_bots` so only new events are processed going forward.
- **Startup hash-ring race**: old pod's heartbeat still alive in Redis during the 5s jitter sleep → hash ring had 2 workers → new pod claimed 0 bots. Self-healing loop now always runs `_claim_orphaned_bots` every 15s (not only on dead worker detection), so bots are reclaimed after the old worker's heartbeat expires.
- **Hung `close_async` blocks graceful shutdown**: could prevent `unregister_worker` from being called, leaving a stale Redis entry for the next deploy. Fix: wrap `close_async` in `asyncio.wait_for` with 5s timeout.

## Root cause from production logs

```
16:01:42 - claiming 0 bots out of 3 total   ← old worker still in ring
16:01:43 - Started Slack bot (via historical ACTIVATE event)
16:01:43 - Stopped slack bot                 ← historical DEACTIVATE/RESTART event
16:01:45 - Started Slack bot
16:01:45 - Stopped slack bot                 ← second historical event, empty session
# → bot never runs again (no self-heal)
```

## Test plan
- [ ] Deploy and confirm bot-worker pod logs show bot starting and staying connected
- [ ] Simulate rolling restart and confirm bot reconnects within ~30s (old heartbeat timeout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)