### PR TITLE
feat: post to LinkedIn company page when configured per-tool

### DIFF
--- a/api/src/services/agents/internal_tools/linkedin_tools.py
+++ b/api/src/services/agents/internal_tools/linkedin_tools.py
@@ -166,6 +166,14 @@ async def _get_linkedin_credentials(
     if not credentials.get("access_token"):
         raise ValueError("No LinkedIn access token available. Please connect LinkedIn.")
 
+    # Attach company page config so posting functions can switch author URN
+    if agent_tool and agent_tool.config:
+        credentials["post_to_company_page"] = bool(agent_tool.config.get("post_to_company_page"))
+        credentials["company_page_id"] = agent_tool.config.get("company_page_id") or ""
+    else:
+        credentials["post_to_company_page"] = False
+        credentials["company_page_id"] = ""
+
     return credentials
 
 
@@ -306,7 +314,10 @@ async def internal_linkedin_post_text(
         if not user_id:
             return {"success": False, "error": "Failed to get user ID"}
 
-        author_urn = f"urn:li:person:{user_id}"
+        if credentials.get("post_to_company_page") and credentials.get("company_page_id"):
+            author_urn = f"urn:li:organization:{credentials['company_page_id']}"
+        else:
+            author_urn = f"urn:li:person:{user_id}"
 
         # Create post using Posts API
         json_data = {
@@ -394,7 +405,10 @@ async def internal_linkedin_share_url(
         if not user_id:
             return {"success": False, "error": "Failed to get user ID"}
 
-        author_urn = f"urn:li:person:{user_id}"
+        if credentials.get("post_to_company_page") and credentials.get("company_page_id"):
+            author_urn = f"urn:li:organization:{credentials['company_page_id']}"
+        else:
+            author_urn = f"urn:li:person:{user_id}"
 
         # Create share with article content
         json_data = {
@@ -663,7 +677,10 @@ async def internal_linkedin_post_with_image(
         if not user_id:
             return {"success": False, "error": "Failed to get user ID"}
 
-        author_urn = f"urn:li:person:{user_id}"
+        if credentials.get("post_to_company_page") and credentials.get("company_page_id"):
+            author_urn = f"urn:li:organization:{credentials['company_page_id']}"
+        else:
+            author_urn = f"urn:li:person:{user_id}"
 
         init_headers = {
             "Authorization": f"Bearer {access_token}",

--- a/web/app/(dashboard)/agents/[agentName]/tools/page.tsx
+++ b/web/app/(dashboard)/agents/[agentName]/tools/page.tsx
@@ -2375,6 +2375,55 @@ export default function AgentToolsPage() {
                 </section>
               )}
 
+              {/* LinkedIn Company Page Section */}
+              {selectedTool.oauthProvider === 'linkedin' &&
+                ['internal_linkedin_post_text', 'internal_linkedin_share_url', 'internal_linkedin_post_with_image'].includes(selectedTool.name) && (
+                <section className={toolModalSectionClass}>
+                  <div className="mb-5">
+                    <h3 className="text-lg font-semibold tracking-[-0.02em] text-[#171717]">Company Page</h3>
+                    <p className="mt-1 text-sm text-[#6d675f]">
+                      Post on behalf of a LinkedIn Company Page instead of the personal account.
+                    </p>
+                  </div>
+                  <div className="flex items-center justify-between rounded-2xl border border-black/8 bg-white/60 px-4 py-3">
+                    <div>
+                      <p className="text-sm font-medium text-[#171717]">Post to Company Page</p>
+                      <p className="text-xs text-[#6d675f] mt-0.5">
+                        When enabled, posts go to the specified company page instead of the personal feed.
+                      </p>
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() => handleConfigChange('post_to_company_page', toolConfig['post_to_company_page'] === 'true' ? 'false' : 'true')}
+                      className={`relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none ${
+                        toolConfig['post_to_company_page'] === 'true' ? 'bg-[#171717]' : 'bg-gray-200'
+                      }`}
+                    >
+                      <span
+                        className={`pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out ${
+                          toolConfig['post_to_company_page'] === 'true' ? 'translate-x-5' : 'translate-x-0'
+                        }`}
+                      />
+                    </button>
+                  </div>
+                  {toolConfig['post_to_company_page'] === 'true' && (
+                    <div className="mt-4">
+                      <label className={toolModalLabelClass}>Company Page ID</label>
+                      <p className={toolModalHelpClass}>
+                        The numeric LinkedIn organization ID (e.g. 12345678). Find it in your LinkedIn Page admin URL or use the &quot;Get Managed Pages&quot; tool.
+                      </p>
+                      <input
+                        type="text"
+                        value={toolConfig['company_page_id'] || ''}
+                        onChange={(e) => handleConfigChange('company_page_id', e.target.value)}
+                        placeholder="e.g. 12345678"
+                        className={toolModalFieldClass}
+                      />
+                    </div>
+                  )}
+                </section>
+              )}
+
               {/* GitHub Account Connection Section */}
               {selectedTool.name === 'github' && (
                 <section className={toolModalSectionClass}>


### PR DESCRIPTION
## Summary

- When a tenant connects LinkedIn via their personal account and enables **Post to Company Page** on a posting tool, content is published to the configured company page using the `urn:li:organization:{id}` author URN instead of the personal `urn:li:person:{id}` URN — no additional OAuth is required because the personal token already grants `w_organization_social` when the user is a page admin
- Three posting tools affected: `internal_linkedin_post_text`, `internal_linkedin_share_url`, `internal_linkedin_post_with_image`
- Config is stored per-tool in `AgentTool.config` (`post_to_company_page: true`, `company_page_id: "12345678"`) via the existing `saveTool()` path — no schema changes needed
- The tool config modal now shows a **Company Page** section with a toggle and a conditional numeric ID input for the three posting tools

## Test plan
- [ ] Enable `internal_linkedin_post_text` tool, open config modal — Company Page section appears below Optional Configuration
- [ ] Toggle "Post to Company Page" on — Company Page ID input appears
- [ ] Enter a page ID and save — `AgentTool.config` stores `post_to_company_page=true` and `company_page_id`
- [ ] Agent posts text — LinkedIn API receives `author: urn:li:organization:{id}` and post appears on the company page
- [ ] Toggle off and save — posts revert to personal author URN
- [ ] Same flow works for `share_url` and `post_with_image`

🤖 Generated with [Claude Code](https://claude.com/claude-code)