### PR TITLE
fix: add diagnostics for widget MCP JWT auth failures

### DIFF
--- a/api/src/controllers/widgets.py
+++ b/api/src/controllers/widgets.py
@@ -1337,6 +1337,28 @@ async def widget_chat(request: WidgetChatRequest, http_request: Request, db: Asy
                 logger.error(f"HMAC verification error for widget {widget.id}: {e}")
                 raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Identity verification failed")
 
+        # ── Sentry: tag/context every widget API call ──────────────────────────────
+        # Tags make widget calls filterable/searchable in Sentry. The logging
+        # integration (see app.py) already turns this logger.info call into a
+        # breadcrumb automatically — no separate add_breadcrumb() needed.
+        import sentry_sdk
+
+        sentry_sdk.set_tag("widget_id", str(widget.id))
+        sentry_sdk.set_tag("widget_source", request.source or "widget")
+        sentry_sdk.set_context(
+            "widget_request",
+            {
+                "widget_id": str(widget.id),
+                "source": request.source,
+                "has_user": bool(request.user),
+                "user_id": request.user.id if request.user else None,
+                "org_id": request.user.org_id if request.user else None,
+                "org_name": request.user.org_name if request.user else None,
+                "identity_verification_required": bool(widget.identity_verification_required),
+            },
+        )
+        logger.info(f"widget chat call: source={request.source} widget_id={widget.id}")
+
         # ── Widget user JWT for MCP servers ───────────────────────────────────────
         # Generate a short-lived signed JWT encoding the verified user context so
         # that MCP tools can forward it as an Authorization Bearer token.  The JWT
@@ -1363,6 +1385,14 @@ async def widget_chat(request: WidgetChatRequest, http_request: Request, db: Asy
                     "email": request.user.email,
                     "org_name": request.user.org_name,
                 }
+                if request.user.org_id is None:
+                    # Send as a standalone Sentry event (not just a breadcrumb) so it's
+                    # visible in Sentry's Issues list without needing an accompanying error.
+                    sentry_sdk.capture_message(
+                        f"widget MCP JWT minted with null organization_id claim "
+                        f"(source={request.source}, widget_id={widget.id}, user_id={request.user.id})",
+                        level="warning",
+                    )
                 _mcp_user_token = _jwt.encode(_payload, _secret, algorithm="HS256")
             except Exception as _jwt_err:
                 logger.warning(f"Could not generate MCP user JWT for widget {widget.id}: {_jwt_err}")

--- a/api/src/services/mcp/mcp_client.py
+++ b/api/src/services/mcp/mcp_client.py
@@ -23,6 +23,22 @@ from src.models import AgentMCPServer, MCPServer
 logger = logging.getLogger(__name__)
 
 
+def _describe_bearer_token(token: str) -> str:
+    """Best-effort, no-verify decode of a bearer token's claims for diagnostics.
+
+    Never logs the raw token — only whether it looks like a JWT and, if so,
+    its non-sensitive claims (everything except any value under "email").
+    """
+    try:
+        import jwt as _jwt
+
+        claims = _jwt.decode(token, options={"verify_signature": False})
+        safe_claims = {k: v for k, v in claims.items() if k != "email"}
+        return f"JWT claims={safe_claims}"
+    except Exception:
+        return f"opaque token (len={len(token)})"
+
+
 class MCPClientError(Exception):
     """Base exception for MCP client errors."""
 
@@ -166,6 +182,7 @@ class MCPClient:
 
             logger.info(f"Creating HTTP transport for {server.name}")
             logger.info(f"URL: {server.url}")
+            logger.info(f"Auth: {_describe_bearer_token(auth) if auth else 'none'}")
 
             return StreamableHttpTransport(server.url, headers=headers, auth=auth)
 
@@ -237,6 +254,14 @@ class MCPClient:
                 logger.warning(f"Ping failed but connection established: {str(e)}")
 
         except Exception as e:
+            # httpx.HTTPStatusError only puts a generic "401 Unauthorized" summary in
+            # str(e) — the server's actual rejection reason is in the response body.
+            response = getattr(e, "response", None)
+            if response is not None:
+                try:
+                    logger.error(f"MCP server response body: {response.text[:1000]}")
+                except Exception:
+                    pass
             logger.error(f"Failed to connect to MCP servers: {str(e)}")
             raise MCPConnectionError(f"Failed to connect to MCP servers: {str(e)}")
 


### PR DESCRIPTION
## Summary
- Widget-originated MCP tool calls to an external MCP server are failing with `401 Unauthorized`, ultimately surfacing to users as `Tool calls require user authentication. Send a Synkora JWT in the Authorization header.`
- Root cause not yet confirmed because existing logging didn't show (a) what claims were in the JWT being sent, or (b) the remote server's actual rejection reason (only `httpx`'s generic `401 Unauthorized` summary).
- This PR adds targeted diagnostics only — no behavior change to the auth flow itself.

## Changes
- `api/src/controllers/widgets.py`: tag/context every widget chat call in Sentry (`widget_id`, `source`, `org_id`, `has_user`); fire a standalone Sentry warning event when the MCP JWT is minted with a `null` `organization_id` claim (a likely cause, since `orgId` is optional on the host app's `user` config).
- `api/src/services/mcp/mcp_client.py`: log the bearer token's decoded claims (never the raw signed token, email stripped) before every MCP connection attempt; capture the actual response body from a failed connection instead of just the generic `401 Unauthorized` string.

## Test plan
- [ ] Deploy to production
- [ ] Reproduce the failing MCP tool call from the affected client
- [ ] Confirm logs now show the JWT claims sent and the remote server's actual rejection body
- [ ] Use that to fix the root cause in a follow-up PR