### PR TITLE
fix: production logging, data source sync, and skills S3 bucket issues

### DIFF
--- a/api/src/app.py
+++ b/api/src/app.py
@@ -101,6 +101,11 @@ async def lifespan(app: FastAPI):  # noqa: ARG001
     # Track background tasks for cleanup
     background_tasks: list[asyncio.Task] = []
 
+    # Re-assert logging config at the point the server actually starts serving —
+    # Uvicorn's own worker init can run its own dictConfig() after create_app()
+    # already called setup_logging(), silently reverting it. See setup_logging().
+    setup_logging()
+
     # Startup
     logging.info("Starting up Synkora API...")
 
@@ -333,7 +338,9 @@ def create_app() -> FastAPI:
                     event_level=logging.ERROR,
                 ),
             ],
-            traces_sample_rate=1.0 if settings.app_debug else 0.1,
+            # 1.0 = every request becomes a Sentry transaction (previously 10% in
+            # production), so all requests are visible, not just a sample.
+            traces_sample_rate=1.0,
             profiles_sample_rate=1.0 if settings.app_debug else 0.1,
             send_default_pii=False,  # Don't send PII by default
         )
@@ -682,11 +689,20 @@ class ConnectionTerminationFilter(logging.Filter):
 
 
 def setup_logging() -> None:
-    """Setup application logging."""
+    """Setup application logging.
+
+    force=True is required under Gunicorn+UvicornWorker: the worker's own
+    logging.config.dictConfig() runs during process init and can leave the
+    root logger with no handlers (or a level higher than INFO) by the time
+    this call happens, silently making basicConfig() a no-op otherwise —
+    which drops every logger.info()/.warning() call in the app. force=True
+    strips whatever's on the root logger first, so this call always wins.
+    """
     log_level = logging.DEBUG if settings.app_debug else logging.INFO
     logging.basicConfig(
         level=log_level,
         format="[%(asctime)s] %(levelname)s in %(module)s: %(message)s",
+        force=True,
     )
 
     # Suppress noisy connection termination errors from SQLAlchemy async pool

--- a/api/src/celery_app.py
+++ b/api/src/celery_app.py
@@ -171,10 +171,10 @@ celery_app.conf.update(
             "task": "tasks.generate_all_daily_digests",
             "schedule": crontab(hour=23, minute=0),
         },
-        # Fan out due data source syncs (sync_frequency_minutes-based) every 5 minutes.
+        # Fan out due data source syncs (sync_frequency_minutes-based) every hour.
         "dispatch-due-data-source-syncs": {
             "task": "sync_all_data_sources_task",
-            "schedule": crontab(minute="*/5"),
+            "schedule": crontab(minute=0),
         },
         # Poll pending LLM batch jobs every 30 minutes
         "poll-llm-batches": {

--- a/api/src/controllers/agents/skills.py
+++ b/api/src/controllers/agents/skills.py
@@ -53,12 +53,10 @@ async def add_predefined_skill(
         Upload confirmation with file details
     """
     try:
-        import os
-
-        import boto3
         from botocore.exceptions import ClientError
 
         from src.services.agents.context_file_processor import AgentContextFileProcessor
+        from src.services.storage.s3_storage import S3StorageService
 
         # Get agent from database
         result = await db.execute(select(Agent).filter(Agent.slug == agent_slug, Agent.tenant_id == tenant_id))
@@ -70,15 +68,17 @@ async def add_predefined_skill(
         skill_id = request.skill_id
         skill_category = request.skill_category
 
-        # Fetch skill content from S3
-        skills_bucket = os.getenv("SKILLS_S3_BUCKET", "synkora-skills")
+        # Fetch skill content from S3 — reuse the same bucket/credentials/region
+        # config as the rest of the app (AWS_S3_BUCKET) instead of a separate,
+        # never-provisioned SKILLS_S3_BUCKET bucket.
+        s3_service = S3StorageService()
+        skills_bucket = s3_service.bucket_name
         s3_key = f"claude-skills/{skill_category}/{skill_id}/SKILL.md"
 
         logger.info(f"Fetching skill from S3: s3://{skills_bucket}/{s3_key}")
 
         try:
-            s3_client = boto3.client("s3")
-            response = s3_client.get_object(Bucket=skills_bucket, Key=s3_key)
+            response = s3_service.s3_client.get_object(Bucket=skills_bucket, Key=s3_key)
             skill_content = response["Body"].read().decode("utf-8")
         except ClientError as e:
             error_code = e.response.get("Error", {}).get("Code", "Unknown")

--- a/api/src/controllers/data_sources.py
+++ b/api/src/controllers/data_sources.py
@@ -151,6 +151,32 @@ async def get_default_tenant(db: AsyncSession) -> UUID:
     return tenant.id
 
 
+# Types with a real connector implementation, i.e. an external system that can
+# actually be polled/synced. Everything else in DataSourceType (MANUAL, WEB,
+# CUSTOM, ASANA, GOOGLE_DRIVE, CSV_FILE, ZIP_FILE, ...) is either upload-only
+# (no external source to sync from) or not yet implemented. Used both to build
+# connectors below and to keep the periodic auto-sync dispatcher (see
+# src/tasks/data_source_tasks.py) from ever queuing a sync for a type that has
+# nowhere to sync from.
+SYNCABLE_DATA_SOURCE_TYPES = frozenset(
+    {
+        DataSourceType.SLACK,
+        DataSourceType.GMAIL,
+        DataSourceType.GITHUB,
+        DataSourceType.GITLAB,
+        DataSourceType.TELEGRAM,
+        DataSourceType.DATADOG,
+        DataSourceType.DATABRICKS,
+        DataSourceType.DOCKER_LOGS,
+        DataSourceType.NOTION,
+        DataSourceType.CONFLUENCE,
+        DataSourceType.JIRA,
+        DataSourceType.CLICKUP,
+        DataSourceType.LINEAR,
+    }
+)
+
+
 def get_connector(data_source: DataSource, db: AsyncSession):
     """Get the appropriate connector for a data source."""
     if data_source.type == DataSourceType.SLACK:
@@ -361,6 +387,10 @@ async def create_data_source(
             oauth_app_id=request.oauth_app_id,
             slack_bot_id=slack_bot_uuid,
             status=initial_status,
+            # sync_enabled defaults to True at the model level for every type —
+            # force it off for types with no connector (nothing to poll), so the
+            # periodic auto-sync dispatcher never has a reason to pick these up.
+            sync_enabled=request.type in SYNCABLE_DATA_SOURCE_TYPES,
         )
 
         db.add(data_source)
@@ -734,6 +764,12 @@ async def trigger_sync(
 
         if ds.status not in (DataSourceStatus.ACTIVE, DataSourceStatus.ERROR):
             raise HTTPException(status_code=400, detail="Data source is not active. Please complete OAuth first.")
+
+        if ds.type not in SYNCABLE_DATA_SOURCE_TYPES:
+            raise HTTPException(
+                status_code=400,
+                detail=f"{ds.type.value} data sources have no external system to sync from — nothing to trigger.",
+            )
 
         # Prevent duplicate concurrent syncs
         result = await db.execute(

--- a/api/src/services/agents/llm_batch_client.py
+++ b/api/src/services/agents/llm_batch_client.py
@@ -59,44 +59,48 @@ class OpenAIBatchClient:
 
         Returns the batch_id string.
         """
-        client = self._make_client()
-
-        # Build JSONL content
-        lines = []
-        for req in requests:
-            msgs = list(req.messages)
-            if req.system_prompt:
-                msgs = [{"role": "system", "content": req.system_prompt}] + msgs
-            lines.append(
-                json.dumps(
-                    {
-                        "custom_id": req.custom_id,
-                        "method": "POST",
-                        "url": "/v1/chat/completions",
-                        "body": {
-                            "model": req.model or self.model,
-                            "messages": msgs,
-                            "max_completion_tokens": req.max_tokens,
-                        },
-                    }
+        # async with ensures the SDK client (and its underlying httpx.AsyncClient)
+        # closes deterministically before this coroutine returns — Celery tasks
+        # run this inside a manually-managed event loop that gets closed right
+        # after, and an unclosed client's cleanup then fires on a dead loop
+        # ("Task exception was never retrieved: ... Event loop is closed").
+        async with self._make_client() as client:
+            # Build JSONL content
+            lines = []
+            for req in requests:
+                msgs = list(req.messages)
+                if req.system_prompt:
+                    msgs = [{"role": "system", "content": req.system_prompt}] + msgs
+                lines.append(
+                    json.dumps(
+                        {
+                            "custom_id": req.custom_id,
+                            "method": "POST",
+                            "url": "/v1/chat/completions",
+                            "body": {
+                                "model": req.model or self.model,
+                                "messages": msgs,
+                                "max_completion_tokens": req.max_tokens,
+                            },
+                        }
+                    )
                 )
+            jsonl_bytes = "\n".join(lines).encode()
+
+            # Upload file
+            file_obj = await client.files.create(
+                file=("batch_requests.jsonl", jsonl_bytes, "application/jsonl"),
+                purpose="batch",
             )
-        jsonl_bytes = "\n".join(lines).encode()
 
-        # Upload file
-        file_obj = await client.files.create(
-            file=("batch_requests.jsonl", jsonl_bytes, "application/jsonl"),
-            purpose="batch",
-        )
-
-        # Create batch
-        batch = await client.batches.create(
-            input_file_id=file_obj.id,
-            endpoint="/v1/chat/completions",
-            completion_window="24h",
-        )
-        logger.info(f"OpenAI batch submitted: {batch.id} ({len(requests)} requests)")
-        return batch.id
+            # Create batch
+            batch = await client.batches.create(
+                input_file_id=file_obj.id,
+                endpoint="/v1/chat/completions",
+                completion_window="24h",
+            )
+            logger.info(f"OpenAI batch submitted: {batch.id} ({len(requests)} requests)")
+            return batch.id
 
     async def poll(self, batch_id: str) -> tuple[str, list[BatchResult] | None]:
         """
@@ -106,19 +110,19 @@ class OpenAIBatchClient:
         status values: "validating" | "in_progress" | "completed" | "failed" | "expired"
         results is None unless status == "completed".
         """
-        client = self._make_client()
-        batch = await client.batches.retrieve(batch_id)
-        status = batch.status
+        async with self._make_client() as client:
+            batch = await client.batches.retrieve(batch_id)
+            status = batch.status
 
-        if status != "completed":
-            return status, None
+            if status != "completed":
+                return status, None
 
-        if not batch.output_file_id:
-            return "failed", None
+            if not batch.output_file_id:
+                return "failed", None
 
-        # Download results
-        file_content = await client.files.content(batch.output_file_id)
-        raw_text = file_content.text if hasattr(file_content, "text") else file_content.decode()
+            # Download results
+            file_content = await client.files.content(batch.output_file_id)
+            raw_text = file_content.text if hasattr(file_content, "text") else file_content.decode()
 
         results: list[BatchResult] = []
         for line in raw_text.strip().splitlines():
@@ -169,22 +173,21 @@ class AnthropicBatchClient:
 
     async def submit(self, requests: list[BatchRequest]) -> str:
         """Submit a batch and return batch_id."""
-        client = self._make_client()
+        async with self._make_client() as client:
+            batch_requests = []
+            for req in requests:
+                params: dict = {
+                    "model": req.model or self.model,
+                    "max_tokens": req.max_tokens,
+                    "messages": req.messages,
+                }
+                if req.system_prompt:
+                    params["system"] = req.system_prompt
+                batch_requests.append({"custom_id": req.custom_id, "params": params})
 
-        batch_requests = []
-        for req in requests:
-            params: dict = {
-                "model": req.model or self.model,
-                "max_tokens": req.max_tokens,
-                "messages": req.messages,
-            }
-            if req.system_prompt:
-                params["system"] = req.system_prompt
-            batch_requests.append({"custom_id": req.custom_id, "params": params})
-
-        batch = await client.beta.messages.batches.create(requests=batch_requests)
-        logger.info(f"Anthropic batch submitted: {batch.id} ({len(requests)} requests)")
-        return batch.id
+            batch = await client.beta.messages.batches.create(requests=batch_requests)
+            logger.info(f"Anthropic batch submitted: {batch.id} ({len(requests)} requests)")
+            return batch.id
 
     async def poll(self, batch_id: str) -> tuple[str, list[BatchResult] | None]:
         """
@@ -193,32 +196,32 @@ class AnthropicBatchClient:
         Returns (status, results_or_None).
         status values: "in_progress" | "ended"
         """
-        client = self._make_client()
-        batch = await client.beta.messages.batches.retrieve(batch_id)
-        status = batch.processing_status  # "in_progress" | "ended"
+        async with self._make_client() as client:
+            batch = await client.beta.messages.batches.retrieve(batch_id)
+            status = batch.processing_status  # "in_progress" | "ended"
 
-        if status != "ended":
-            return status, None
+            if status != "ended":
+                return status, None
 
-        # Stream results
-        results: list[BatchResult] = []
-        async for result in await client.beta.messages.batches.results(batch_id):
-            custom_id = result.custom_id
-            if result.result.type == "succeeded":
-                msg = result.result.message
-                content = msg.content[0].text if msg.content else None
-                results.append(
-                    BatchResult(
-                        custom_id=custom_id,
-                        content=content,
-                        error=None,
-                        input_tokens=msg.usage.input_tokens,
-                        output_tokens=msg.usage.output_tokens,
+            # Stream results
+            results: list[BatchResult] = []
+            async for result in await client.beta.messages.batches.results(batch_id):
+                custom_id = result.custom_id
+                if result.result.type == "succeeded":
+                    msg = result.result.message
+                    content = msg.content[0].text if msg.content else None
+                    results.append(
+                        BatchResult(
+                            custom_id=custom_id,
+                            content=content,
+                            error=None,
+                            input_tokens=msg.usage.input_tokens,
+                            output_tokens=msg.usage.output_tokens,
+                        )
                     )
-                )
-            else:
-                error = getattr(result.result, "error", None)
-                results.append(BatchResult(custom_id=custom_id, content=None, error=str(error)))
+                else:
+                    error = getattr(result.result, "error", None)
+                    results.append(BatchResult(custom_id=custom_id, content=None, error=str(error)))
 
         return "completed", results
 

--- a/api/src/services/data_sources/base_connector.py
+++ b/api/src/services/data_sources/base_connector.py
@@ -9,7 +9,7 @@ from typing import Any
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from src.models.data_source import DataSource
+from src.models.data_source import DataSource, DataSourceStatus
 from src.services.data_sources.document_processor import DocumentProcessor
 
 logger = logging.getLogger(__name__)
@@ -191,6 +191,17 @@ class BaseConnector(ABC):
 
             # Update data source with error
             self.data_source.last_error = error_msg
+
+            # A ConnectionError here means connect() itself failed (bad/corrupted
+            # credentials, decryption failure, revoked token, etc.) — not a
+            # transient issue expected to self-heal. Leaving status ACTIVE means
+            # the periodic sync_all_data_sources_task dispatcher keeps re-picking
+            # this data source up and failing identically forever. Mark it ERROR
+            # so it's excluded from auto-dispatch until someone fixes the
+            # credentials (which should reset status back to ACTIVE).
+            if isinstance(e, ConnectionError):
+                self.data_source.status = DataSourceStatus.ERROR
+
             await self.db.commit()
 
             return {

--- a/api/src/services/data_sources/slack_connector.py
+++ b/api/src/services/data_sources/slack_connector.py
@@ -55,6 +55,21 @@ class SlackConnector(BaseConnector):
             logger.error(f"Unexpected error connecting to Slack: {e}")
             return False
 
+    def _try_decrypt(self, encrypted: str, source_label: str) -> str | None:
+        """Decrypt a candidate token, or None (never raise) so the caller can fall
+        through to the next candidate in the priority chain instead of aborting
+        the whole lookup on one corrupted/stale credential."""
+        from src.services.agents.security import decrypt_value
+
+        try:
+            return decrypt_value(encrypted)
+        except Exception as e:
+            logger.warning(
+                f"Could not decrypt {source_label} for data source {self.data_source.name} "
+                f"— skipping to next credential source: {e}"
+            )
+            return None
+
     async def _get_access_token(self) -> str | None:
         """
         Get decrypted access token using user-first resolution.
@@ -64,12 +79,14 @@ class SlackConnector(BaseConnector):
         2. User's personal OAuth token (from UserOAuthToken table)
         3. Data source's direct access_token_encrypted
         4. OAuth app's admin token (fallback)
+
+        A candidate that fails to decrypt is skipped (not fatal) so one corrupted
+        or revoked credential doesn't block falling through to the next source.
         """
         from uuid import UUID as UUIDType
 
         from src.models.slack_bot import SlackBot
         from src.models.user_oauth_token import UserOAuthToken
-        from src.services.agents.security import decrypt_value
 
         # First, try to reuse an existing agent's Slack bot connection
         if self.data_source.slack_bot_id:
@@ -78,7 +95,9 @@ class SlackConnector(BaseConnector):
 
             if slack_bot and slack_bot.slack_bot_token:
                 logger.info(f"Using linked SlackBot token for data source {self.data_source.name}")
-                return decrypt_value(slack_bot.slack_bot_token)
+                token = self._try_decrypt(slack_bot.slack_bot_token, "linked SlackBot token")
+                if token:
+                    return token
 
         # Next, try to get user's personal token if OAuth app is linked
         if self.data_source.oauth_app_id:
@@ -105,7 +124,9 @@ class SlackConnector(BaseConnector):
 
                     if user_token and user_token.access_token:
                         logger.info(f"Using user's personal Slack token for data source {self.data_source.name}")
-                        return decrypt_value(user_token.access_token)
+                        token = self._try_decrypt(user_token.access_token, "user's personal token")
+                        if token:
+                            return token
             else:
                 # No specific user - try to find any user token for this tenant/oauth_app
                 # This handles cases where the data source was created before we tracked account_id
@@ -116,19 +137,25 @@ class SlackConnector(BaseConnector):
 
                 if user_token and user_token.access_token:
                     logger.info(f"Using first available user token for Slack data source {self.data_source.name}")
-                    return decrypt_value(user_token.access_token)
+                    token = self._try_decrypt(user_token.access_token, "first available user token")
+                    if token:
+                        return token
 
         # Fall back to data source's direct token
         if self.data_source.access_token_encrypted:
             logger.info(f"Using data source's direct token for {self.data_source.name}")
-            return decrypt_value(self.data_source.access_token_encrypted)
+            token = self._try_decrypt(self.data_source.access_token_encrypted, "data source's direct token")
+            if token:
+                return token
 
         # Fall back to OAuth app's admin token
         if self.data_source.oauth_app_id and self.data_source.oauth_app:
             oauth_app = self.data_source.oauth_app
             if oauth_app.access_token:
                 logger.info(f"Using OAuth app admin token for Slack data source {self.data_source.name}")
-                return decrypt_value(oauth_app.access_token)
+                token = self._try_decrypt(oauth_app.access_token, "OAuth app admin token")
+                if token:
+                    return token
 
         return None
 

--- a/api/src/tasks/data_source_tasks.py
+++ b/api/src/tasks/data_source_tasks.py
@@ -116,6 +116,7 @@ async def _mark_sync_job_failed(sync_job_id: int, error: str) -> None:
 async def _dispatch_all_syncs(tenant_id: str | None) -> dict[str, Any]:
     from sqlalchemy import select
 
+    from src.controllers.data_sources import SYNCABLE_DATA_SOURCE_TYPES
     from src.core.database import create_celery_async_session
     from src.models.data_source import DataSource, DataSourceStatus, DataSourceSyncJob, SyncStatus
 
@@ -123,6 +124,7 @@ async def _dispatch_all_syncs(tenant_id: str | None) -> dict[str, Any]:
         q = select(DataSource).where(
             DataSource.status == DataSourceStatus.ACTIVE,
             DataSource.sync_enabled.is_(True),
+            DataSource.type.in_(SYNCABLE_DATA_SOURCE_TYPES),
         )
         if tenant_id:
             from uuid import UUID


### PR DESCRIPTION
## Summary
Fixes several issues surfaced via Sentry after enabling full request tracing (`traces_sample_rate=1.0`):

- **Logging silently broken in production**: `logging.basicConfig()` wasn't taking effect under Gunicorn+UvicornWorker — root logger had no handlers, dropping nearly all `logger.info()`/`logger.warning()` calls app-wide. Fixed with `force=True`, re-asserted at `lifespan` startup.
- **Sentry only sampling 10% of requests** in production — bumped `traces_sample_rate` to `1.0` so all requests are visible.
- **`sync_data_source_task` repeatedly failing (12k+ Sentry events)** for `MANUAL`/upload-only data sources — these have no connector (`get_connector()` raises `ValueError`), but the periodic dispatcher and manual "sync now" endpoint never filtered by type, and `sync_enabled` defaulted to `True` for every type including upload-only ones. Added `SYNCABLE_DATA_SOURCE_TYPES` as a single source of truth used in all three places.
- **Data sources with a permanently broken connection retried forever** — a hard `connect()` failure never changed `status` away from `ACTIVE`, so the periodic dispatcher kept re-selecting and re-failing it every cycle. Now marked `ERROR` (manual retry from the UI still works).
- **Slack connector aborted on any decrypt failure** — its 4-tier credential fallback chain (linked bot token → user token → direct token → OAuth app token) now falls through to the next candidate instead of failing the whole lookup on one corrupted/revoked token.
- **`poll_llm_batches` — "Event loop is closed"**: `OpenAIBatchClient`/`AnthropicBatchClient` created SDK clients but never closed them; the underlying `httpx.AsyncClient` got garbage-collected and tried to clean up after the task's manually-managed event loop already closed. Now used as async context managers.
- **`/agents/{slug}/skills/add` — `NoSuchBucket` on every call**: was reading from a never-provisioned `SKILLS_S3_BUCKET` env var (hardcoded fallback `"synkora-skills"`, a bucket that doesn't exist). Now uses `S3StorageService` (same `AWS_S3_BUCKET`/credentials as the rest of the app).
- Periodic data-source-sync dispatcher (`dispatch-due-data-source-syncs`) changed from every 5 minutes to hourly.

## Changes
- `api/src/app.py`
- `api/src/celery_app.py`
- `api/src/controllers/agents/skills.py`
- `api/src/controllers/data_sources.py`
- `api/src/services/agents/llm_batch_client.py`
- `api/src/services/data_sources/base_connector.py`
- `api/src/services/data_sources/slack_connector.py`
- `api/src/tasks/data_source_tasks.py`

## Test plan
- [ ] Deploy to production
- [ ] Confirm INFO/WARNING logs now appear in pod logs
- [ ] Confirm the `MANUAL`-type data source no longer generates repeated Sentry events
- [ ] Confirm `poll_llm_batches` no longer throws "Event loop is closed"
- [ ] Confirm `/agents/{slug}/skills/add` no longer returns `NoSuchBucket`