### PR TITLE
fix: prevent duplicate bot claims across bot-worker instances

### DIFF
--- a/api/src/bot_worker/redis_state.py
+++ b/api/src/bot_worker/redis_state.py
@@ -120,6 +120,7 @@ class BotRedisState:
     KEY_BOT_ASSIGNMENTS = "bot_worker:assignments"  # Hash: bot_id -> worker_id
     KEY_BOT_EVENTS = "bot_worker:events"  # Stream: bot lifecycle events
     KEY_WORKER_COMMANDS = "bot_worker:commands:"  # Pub/sub: commands to specific worker
+    KEY_BOT_CLAIM_LOCK = "bot_worker:claim_lock:"  # String w/ TTL: bot_id -> claiming worker_id
 
     def __init__(self, redis_client: redis.Redis):
         """Initialize with a Redis client.
@@ -247,6 +248,32 @@ class BotRedisState:
         return self.redis.zrangebyscore(self.KEY_WORKER_HEARTBEATS, "-inf", cutoff)
 
     # ==================== Bot Assignment Management ====================
+
+    def try_claim_bot_lock(self, bot_id: str, worker_id: str, ttl_seconds: int = 30) -> bool:
+        """Atomically claim the right to start a bot.
+
+        assign_bot() is a plain HSET (last-write-wins) with no compare-and-swap,
+        so two workers independently deciding "this bot looks orphaned, I'll
+        start it" can both pass that check and both start duplicate connections
+        (visible as Telegram's "Conflict: terminated by other getUpdates
+        request", and silently for Slack Socket Mode, which doesn't error on
+        duplicate connections the same way). This lock closes that race: only
+        the worker that wins the atomic SET NX may proceed to _start_bot().
+
+        The TTL is a safety net, not the primary release mechanism — release_bot_lock()
+        should be called once assign_bot() has recorded ownership (success or
+        failure), but if the claiming worker dies before that, the lock still
+        expires on its own instead of permanently blocking reassignment.
+
+        Returns:
+            True if this worker won the claim, False if another worker holds it.
+        """
+        key = f"{self.KEY_BOT_CLAIM_LOCK}{bot_id}"
+        return bool(self.redis.set(key, worker_id, nx=True, ex=ttl_seconds))
+
+    def release_bot_lock(self, bot_id: str) -> None:
+        """Release a claim lock acquired via try_claim_bot_lock()."""
+        self.redis.delete(f"{self.KEY_BOT_CLAIM_LOCK}{bot_id}")
 
     def assign_bot(self, bot_id: str, worker_id: str, bot_type: BotType) -> None:
         """Assign a bot to a worker.

--- a/api/src/bot_worker/worker.py
+++ b/api/src/bot_worker/worker.py
@@ -288,7 +288,30 @@ class BotWorker:
                 jitter = random.uniform(0, self.config.startup_jitter_max)
                 await asyncio.sleep(jitter)
 
-                await self._start_bot(bot_id, db)
+                await self._claim_and_start_bot(bot_id, db)
+
+    async def _claim_and_start_bot(self, bot_id: str, db: AsyncSession) -> bool:
+        """Atomically claim a bot before starting it.
+
+        Multiple workers can independently decide the same bot needs (re)starting
+        at roughly the same time — e.g. several new pods racing through
+        _claim_assigned_bots() during a scale-up, or _claim_orphaned_bots()
+        running on multiple workers within the same 15s window. Without this,
+        two workers can both start a live connection for the same bot
+        simultaneously (Telegram rejects the duplicate loudly with a Conflict
+        error; Slack Socket Mode does not error, it just silently runs two
+        independent connections/handler instances for the same bot). Only the
+        worker that wins the atomic claim lock proceeds.
+        """
+        loop = asyncio.get_event_loop()
+        won = await loop.run_in_executor(None, lambda: self.redis_state.try_claim_bot_lock(bot_id, self.worker_id))
+        if not won:
+            logger.debug(f"Bot {bot_id} claim lock held by another worker, skipping")
+            return False
+        try:
+            return await self._start_bot(bot_id, db)
+        finally:
+            await loop.run_in_executor(None, lambda: self.redis_state.release_bot_lock(bot_id))
 
     async def _get_all_active_bot_ids(self, db: AsyncSession) -> list[str]:
         """Get all active bot IDs from the database.
@@ -940,13 +963,13 @@ class BotWorker:
 
         async with get_async_session_factory()() as db:
             if event.event_type == BotEventType.ACTIVATE:
-                await self._start_bot(event.bot_id, db)
+                await self._claim_and_start_bot(event.bot_id, db)
             elif event.event_type == BotEventType.DEACTIVATE:
                 await self._stop_bot(event.bot_id)
             elif event.event_type == BotEventType.RESTART:
                 await self._stop_bot(event.bot_id)
                 await asyncio.sleep(1)
-                await self._start_bot(event.bot_id, db)
+                await self._claim_and_start_bot(event.bot_id, db)
 
     async def _command_listener_loop(self) -> None:
         """Listen for direct commands via Redis pub/sub."""
@@ -984,13 +1007,13 @@ class BotWorker:
 
         async with get_async_session_factory()() as db:
             if action == "start_bot" and bot_id:
-                await self._start_bot(bot_id, db)
+                await self._claim_and_start_bot(bot_id, db)
             elif action == "stop_bot" and bot_id:
                 await self._stop_bot(bot_id)
             elif action == "restart_bot" and bot_id:
                 await self._stop_bot(bot_id)
                 await asyncio.sleep(1)
-                await self._start_bot(bot_id, db)
+                await self._claim_and_start_bot(bot_id, db)
             else:
                 logger.warning(f"Unknown command: {command}")
 
@@ -1048,4 +1071,4 @@ class BotWorker:
                                 logger.debug(f"Bot {bot_id} is owned by healthy worker {assigned_worker}, skipping")
                                 continue
                     logger.info(f"Claiming orphaned bot {bot_id}")
-                    await self._start_bot(bot_id, db)
+                    await self._claim_and_start_bot(bot_id, db)


### PR DESCRIPTION
## Summary

Follow-up to #177. That PR fixed bot-worker pods crash-looping under load (blocking Redis calls stalling the event loop). This PR fixes a separate, more serious bug that surfaced once pods stopped crash-looping: **two workers can simultaneously claim and start the same bot.**

`assign_bot()` is a plain `HSET` — last-write-wins, no compare-and-swap. So two workers independently deciding "this bot looks orphaned, I'll start it" (in `_claim_orphaned_bots`, `_claim_assigned_bots`, or the event-/command-driven start paths) can both pass that check and both start a live connection for the same bot at once.

- **Telegram** rejects the duplicate loudly: `telegram.error.Conflict: terminated by other getUpdates request; make sure that only one bot instance is running` — observed repeating every ~30s in production logs.
- **Slack Socket Mode** does not error the same way — it silently runs two independent connections/handler instances for the same bot, so incoming messages route unpredictably between them (this is what was causing "hangs" on alternating messages to a Slack bot).

Confirmed live in production: one bot-worker had been running a Slack bot continuously — including successfully handling a real message — while a second worker claimed the same bot as "orphaned" ~6.5 minutes later, with no evidence the first worker ever released it.

## Fix

- `redis_state.py`: `try_claim_bot_lock(bot_id, worker_id, ttl_seconds=30)` / `release_bot_lock(bot_id)` — an atomic Redis `SET NX EX` lock. Only the worker that wins the claim proceeds to start the bot. The TTL is a safety net: if a worker dies mid-claim before releasing, the lock still expires on its own rather than permanently blocking reassignment.
- `worker.py`: new `_claim_and_start_bot()` helper wraps claim → start → release. Wired into all four places a bot gets started: `_claim_assigned_bots` (startup), `_claim_orphaned_bots` (the confirmed active race), and the event-driven (`_handle_bot_event`) and command-driven (`_handle_command`) start paths, for consistency.

## Test plan
- [ ] Deploy to production
- [ ] Confirm the Telegram `Conflict` errors stop recurring
- [ ] Confirm a Slack bot handles consecutive messages reliably (no more alternating hang)
- [ ] Confirm only one `Started Slack bot X` log line per bot per claim, with a clear stop before any reclaim