### PR TITLE
fix: stop bot-worker HPA scale-up thrashing

### DIFF
--- a/api/seed_platform_engineer_agent.py
+++ b/api/seed_platform_engineer_agent.py
@@ -34,7 +34,7 @@ PLATFORM_ENGINEER_SYSTEM_PROMPT = """You are the Platform Engineer — an AI age
 2. `platform_get_available_tools()` — return all tool categories with descriptions and OAuth requirements
 3. `platform_check_integration(provider)` — check if a specific OAuth integration is connected
 4. `platform_create_agent(...)` — create a new agent (requires confirmation flow below)
-5. `platform_update_agent(...)` — update an existing agent's description, prompt, status, or tools. Pass `tools_list` to enable tool categories. **The backend automatically copies your LLM config (API key, provider, model) to the updated agent — you do NOT need to find or reference yourself.**
+5. `platform_update_agent(...)` — update an existing agent's description, prompt, status, tools, or slug. Pass `tools_list` to enable tool categories. Pass `slug` to fix an agent that has no slug (only works when the agent's slug is currently unset — a slug that is already assigned cannot be changed). **The backend automatically copies your LLM config (API key, provider, model) to the updated agent — you do NOT need to find or reference yourself.**
 6. `platform_list_database_connections(connection_type, agent_name)` — list active database connections for the tenant and optionally show which ones are attached to an agent
 7. `platform_attach_database_connections(agent_name, connection_ids, connection_type, replace)` — attach active database connections to an agent by explicit IDs or by database type
 8. `platform_list_knowledge_bases(status, agent_name)` — list tenant knowledge bases and optionally show whether they are attached to an agent

--- a/api/src/services/agents/internal_tools/platform_tools.py
+++ b/api/src/services/agents/internal_tools/platform_tools.py
@@ -627,6 +627,15 @@ async def platform_create_agent(
             # Append a short suffix
             agent_name_slug = f"{agent_name_slug}_{uuid4().hex[:4]}"
 
+        # Build a globally-unique slug for URL routing (Agent.slug is unique across all
+        # tenants, unlike agent_name which is only unique per-tenant).
+        base_slug = re.sub(r"[^a-z0-9-]", "-", name.lower())
+        base_slug = re.sub(r"-+", "-", base_slug).strip("-") or "agent"
+        agent_slug = base_slug
+        existing_slug = await db.execute(select(Agent).where(Agent.slug == agent_slug))
+        if existing_slug.scalar_one_or_none():
+            agent_slug = f"{base_slug}-{uuid4().hex[:6]}"
+
         # Inherit full LLM config from PE's per-tenant config when no api_key supplied
         llm_temperature: float = 0.7
         llm_max_tokens: int = 4096
@@ -696,6 +705,7 @@ async def platform_create_agent(
             id=uuid4(),
             tenant_id=tenant_id,
             agent_name=agent_name_slug,
+            slug=agent_slug,
             agent_type=agent_type,
             description=description,
             system_prompt=system_prompt,
@@ -843,6 +853,7 @@ async def platform_create_agent(
         return {
             "success": True,
             "agent_name": agent_name_slug,
+            "slug": agent_slug,
             "agent_id": str(agent.id),
             "message": f"Agent '{agent_name_slug}' created successfully.{attached_msg}",
             "knowledge_bases_attached": kb_results,
@@ -1084,10 +1095,11 @@ async def platform_update_agent(
     tools_list: list[str] | None = None,
     image_llm_provider: str | None = None,
     image_llm_model: str | None = None,
+    slug: str | None = None,
     runtime_context: Any = None,
 ) -> dict:
     """
-    Update an existing agent's description, system prompt, status, or tools.
+    Update an existing agent's description, system prompt, status, tools, or slug.
 
     Only updates fields that are explicitly provided (not None).
     Security: always scoped to the current tenant.
@@ -1100,6 +1112,9 @@ async def platform_update_agent(
         tools_list: List of tool category names to enable (optional).
                     Uses the same categories as platform_create_agent.
                     Adds tools without removing existing ones.
+        slug: New URL slug to assign (optional). Only allowed when the agent
+              currently has no slug (e.g. agents created before slug generation
+              was added). A slug that is already set cannot be changed.
 
     Returns:
         dict with success and message
@@ -1130,6 +1145,25 @@ async def platform_update_agent(
             if status.upper() not in ("ACTIVE", "INACTIVE"):
                 return {"success": False, "message": "status must be ACTIVE or INACTIVE"}
             agent.status = status.upper()
+
+        if slug is not None:
+            if agent.slug:
+                return {
+                    "success": False,
+                    "message": f"Agent '{agent_name}' already has a slug ('{agent.slug}') and it cannot be changed.",
+                }
+            import re
+
+            new_slug = re.sub(r"[^a-z0-9-]", "-", slug.lower())
+            new_slug = re.sub(r"-+", "-", new_slug).strip("-")
+            if not new_slug:
+                return {"success": False, "message": "slug must contain at least one letter or number"}
+            existing_slug = (
+                await db.execute(select(Agent).where(Agent.slug == new_slug, Agent.id != agent.id))
+            ).scalar_one_or_none()
+            if existing_slug:
+                return {"success": False, "message": f"Slug '{new_slug}' is already in use by another agent"}
+            agent.slug = new_slug
 
         # Enable tools via AgentTool rows (direct pattern match, not capability groups)
         tools_enabled: list[str] = []
@@ -1284,7 +1318,9 @@ async def platform_update_agent(
         msg = f"Agent '{agent_name}' updated successfully."
         if tools_enabled:
             msg += f" Enabled {len(tools_enabled)} tools."
-        return {"success": True, "message": msg, "tools_enabled": tools_enabled}
+        if slug is not None and agent.slug:
+            msg += f" Slug set to '{agent.slug}'."
+        return {"success": True, "message": msg, "tools_enabled": tools_enabled, "slug": agent.slug}
 
     except Exception as e:
         logger.exception("Error updating agent")

--- a/api/src/services/agents/tool_registrations/platform_tools_registry.py
+++ b/api/src/services/agents/tool_registrations/platform_tools_registry.py
@@ -93,6 +93,7 @@ def register_platform_tools(registry) -> None:
             tools_list=kwargs.get("tools_list"),
             image_llm_provider=kwargs.get("image_llm_provider"),
             image_llm_model=kwargs.get("image_llm_model"),
+            slug=kwargs.get("slug"),
             runtime_context=runtime_context,
         )
 
@@ -340,9 +341,12 @@ def register_platform_tools(registry) -> None:
     registry.register_tool(
         name="platform_update_agent",
         description=(
-            "Update an existing agent's description, system prompt, status, or tools. "
+            "Update an existing agent's description, system prompt, status, tools, or slug. "
             "Use tools_list to add tool capabilities to an existing agent — pass the same "
             "tool category names used in platform_create_agent (e.g. browser_tools, scheduler_tools). "
+            "Use slug to fix an agent that has no slug (e.g. one created before slug generation "
+            "was added) — this only works when the agent's slug is currently unset; a slug that is "
+            "already assigned cannot be changed. "
             "Only updates fields that are explicitly provided."
         ),
         parameters={
@@ -379,6 +383,13 @@ def register_platform_tools(registry) -> None:
                 "image_llm_model": {
                     "type": "string",
                     "description": "Optional image model to assign, e.g. gpt-image-2.",
+                },
+                "slug": {
+                    "type": "string",
+                    "description": (
+                        "New URL slug to assign (optional). Only works when the agent currently "
+                        "has no slug — a slug that is already set cannot be changed."
+                    ),
                 },
             },
             "required": ["agent_name"],

--- a/k8s/application/bot-worker-deployment.yaml
+++ b/k8s/application/bot-worker-deployment.yaml
@@ -123,14 +123,21 @@ spec:
         value: 10
         periodSeconds: 60
     scaleUp:
-      stabilizationWindowSeconds: 0
+      # Every replica-count change reshuffles the consistent-hash bot-to-worker
+      # assignment, forcing live Slack/Telegram connections to tear down and
+      # reconnect elsewhere. For a stateful workload like this, connection
+      # stability matters far more than reacting to a CPU blip within 15s —
+      # matching scaleDown's window so brief spikes don't trigger a burst of
+      # new pods (and the resulting bot reassignment) that settles back down
+      # 5 minutes later anyway.
+      stabilizationWindowSeconds: 300
       policies:
       - type: Percent
         value: 100
-        periodSeconds: 15
+        periodSeconds: 60
       - type: Pods
-        value: 4
-        periodSeconds: 15
+        value: 2
+        periodSeconds: 60
       selectPolicy: Max
 ---
 apiVersion: policy/v1

--- a/web/components/agents/builder-assistant/AgentBuilderSidebar.tsx
+++ b/web/components/agents/builder-assistant/AgentBuilderSidebar.tsx
@@ -35,7 +35,7 @@ export function AgentBuilderSidebar({ onInsertContent, currentContext }: AgentBu
   const [messages, setMessages] = useState<Message[]>([]);
   const [input, setInput] = useState('');
   const [isLoading, setIsLoading] = useState(false);
-  const [conversationId] = useState<string | null>(null);
+  const [conversationId, setConversationId] = useState<string | null>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
 
   const suggestionPrompts: SuggestionPrompt[] = [
@@ -179,6 +179,17 @@ export function AgentBuilderSidebar({ onInsertContent, currentContext }: AgentBu
               }
               return newMessages;
             });
+          }
+
+          if (data.type === 'done') {
+            // Server generates/reuses the real conversation on first message and
+            // returns it here — capture it so subsequent messages continue the
+            // same conversation server-side instead of silently starting a new
+            // one each time (which surfaces later as "Conversation X not found").
+            const metadata = data.metadata as { conversation_id?: string } | undefined;
+            if (metadata?.conversation_id) {
+              setConversationId(metadata.conversation_id);
+            }
           }
         }
       }

--- a/web/components/agents/platform-engineer/screens/ChatScreen.tsx
+++ b/web/components/agents/platform-engineer/screens/ChatScreen.tsx
@@ -22,7 +22,7 @@ export function ChatScreen({ agentName = 'platform_engineer_agent' }: Props) {
   const [messages, setMessages] = useState<ParsedMessage[]>([])
   const [input, setInput] = useState('')
   const [isStreaming, setIsStreaming] = useState(false)
-  const [conversationId] = useState<string | null>(null)
+  const [conversationId, setConversationId] = useState<string | null>(null)
   const [peProvider, setPeProvider] = useState<string>('')
   const [peModelName, setPeModelName] = useState<string>('')
   const scrollRef = useRef<HTMLDivElement>(null)
@@ -148,6 +148,18 @@ export function ChatScreen({ agentName = 'platform_engineer_agent' }: Props) {
               }
               return next
             })
+          }
+
+          if (data.type === 'done') {
+            // Server generates/reuses the real conversation on first message and
+            // returns it here — capture it so every subsequent message (including
+            // the __CONFIRMED__ action-confirm flow) continues the same
+            // conversation server-side instead of silently starting a new one
+            // each time (which is what "Conversation X not found" traced back to).
+            const metadata = data.metadata as { conversation_id?: string } | undefined
+            if (metadata?.conversation_id) {
+              setConversationId(metadata.conversation_id)
+            }
           }
         }
       }
@@ -303,6 +315,13 @@ export function ChatScreen({ agentName = 'platform_engineer_agent' }: Props) {
               }
               return next
             })
+          }
+
+          if (data.type === 'done') {
+            const metadata = data.metadata as { conversation_id?: string } | undefined
+            if (metadata?.conversation_id) {
+              setConversationId(metadata.conversation_id)
+            }
           }
         }
       }


### PR DESCRIPTION
## Summary

Follow-up to #177 and #178. Both of those fixed real bugs in `bot_worker`, but pods were still churning due to a third, infra-level issue: `synkora-bot-worker-hpa`'s `scaleUp.stabilizationWindowSeconds: 0` with a burst policy (double pod count, or +4, every 15s) meant any brief CPU blip triggered an immediate scale-up.

For this workload that's actively harmful, not just wasteful: every replica-count change reshuffles the consistent-hash bot-to-worker assignment, forcing live Slack/Telegram connections to tear down and reconnect elsewhere.

Confirmed live in production: pod count flapped 5→2→5 within minutes, and a Slack bot sat completely unclaimed during one of those transitions until the dead-worker self-heal loop caught it ~15s later.

**Already applied directly to the live HPA via `kubectl patch` for immediate relief** — this PR commits the same change to the manifest so it persists across deploys instead of only living on the cluster (a future deploy would otherwise silently revert it back to the old behavior).

## Change

`scaleUp.stabilizationWindowSeconds`: `0` → `300` (matches `scaleDown`'s existing window), and slows the burst policies from 15s windows to 60s windows, and from +4 pods to +2 pods per step. Sustained load still scales up correctly — it just won't react within 15 seconds of the first CPU tick anymore.

## Test plan
- [ ] Confirm this matches what's already live (`kubectl get hpa synkora-bot-worker-hpa -n synkora-production -o yaml`) so the next deploy doesn't revert it
- [ ] Monitor bot-worker pod count over the following hours — should be far more stable, changing only for genuine sustained load shifts