### PR TITLE
feat: support @-mentioning one agent's Slack bot from another

### DIFF
--- a/api/migrations/versions/20260824_0001_add_slack_bot_user_id.py
+++ b/api/migrations/versions/20260824_0001_add_slack_bot_user_id.py
@@ -1,0 +1,35 @@
+"""add slack_bot_user_id to slack_bots
+
+Revision ID: 20260824_0001
+Revises: 20260817_0002
+Create Date: 2026-08-24
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "20260824_0001"
+down_revision = "20260817_0002"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    existing = bind.execute(
+        sa.text(
+            "SELECT column_name FROM information_schema.columns "
+            "WHERE table_name='slack_bots' AND column_name='slack_bot_user_id'"
+        )
+    ).fetchone()
+    if not existing:
+        op.add_column(
+            "slack_bots",
+            sa.Column("slack_bot_user_id", sa.String(255), nullable=True),
+        )
+
+
+def downgrade() -> None:
+    pass

--- a/api/seed_platform_engineer_agent.py
+++ b/api/seed_platform_engineer_agent.py
@@ -257,6 +257,13 @@ When a user wants to reach an agent (or you) via Slack or Telegram:
 **Connecting yourself:** use `agent_name="platform_engineer_agent"`.
 **Connecting another agent:** use that agent's slug name (from `platform_list_agents()`).
 
+**One bot @-mentioning another bot in Slack:** call `platform_list_agent_channels(agent_name=<target agent>)`
+to get that agent's Slack `slack_bot_user_id` (e.g. "U0123ABC"), then have the requesting agent include
+`<@U0123ABC>` in the message text it sends via `internal_slack_send_message`/`internal_slack_post_blocks` —
+Slack renders that as a proper @-mention/tag of the other bot. This only works for bots created after the
+`slack_bot_user_id` field was added; if it's missing/null for an older bot, tell the user to reconnect that
+bot (re-run `platform_create_slack_bot` with its existing token) to backfill it.
+
 Never ask the user to do any additional steps after you call these tools — the bot activates automatically.
 
 ## Communication style

--- a/api/src/models/slack_bot.py
+++ b/api/src/models/slack_bot.py
@@ -34,6 +34,10 @@ class SlackBot(Base):
     slack_workspace_id = Column(String(255), nullable=True)
     slack_workspace_name = Column(String(255), nullable=True)
 
+    # Slack's own user id for this bot (U.../B...), fetched via auth.test on creation.
+    # Used to @-mention this bot from another bot/agent, e.g. f"<@{slack_bot_user_id}>".
+    slack_bot_user_id = Column(String(255), nullable=True)
+
     # Ownership — account that created/connected this bot (used to resolve OAuth tokens for scheduled runs)
     created_by = Column(UUID(as_uuid=True), ForeignKey("accounts.id", ondelete="SET NULL"), nullable=True)
 

--- a/api/src/services/agents/internal_tools/platform_tools.py
+++ b/api/src/services/agents/internal_tools/platform_tools.py
@@ -2504,7 +2504,9 @@ async def platform_create_slack_bot(
         app_id: Slack App ID (optional — shown in app settings at api.slack.com)
 
     Returns:
-        dict with success, bot_id, workspace_name, and webhook_url (Event Mode only)
+        dict with success, bot_id, workspace_name, webhook_url (Event Mode only), and
+        slack_bot_user_id (Slack's own user id for this bot, e.g. "U0123ABC" — use
+        f"<@{slack_bot_user_id}>" in a message to @-mention this bot from another agent).
     """
     if not runtime_context or not runtime_context.tenant_id:
         return {"success": False, "message": "No tenant context available"}
@@ -2548,6 +2550,8 @@ async def platform_create_slack_bot(
         }
         if slack_bot.webhook_url:
             result["webhook_url"] = slack_bot.webhook_url
+        if slack_bot.slack_bot_user_id:
+            result["slack_bot_user_id"] = slack_bot.slack_bot_user_id
         return result
 
     except Exception as e:
@@ -2633,7 +2637,10 @@ async def platform_list_agent_channels(
         agent_name: Slug name of the agent
 
     Returns:
-        dict with slack (list) and telegram (list) channel summaries
+        dict with slack (list) and telegram (list) channel summaries. Each Slack entry
+        includes slack_bot_user_id (Slack's own user id for that bot, e.g. "U0123ABC") —
+        use f"<@{slack_bot_user_id}>" in a message to @-mention that agent's bot from
+        another agent's bot.
     """
     if not runtime_context or not runtime_context.tenant_id:
         return {"error": "No tenant context available"}
@@ -2677,6 +2684,7 @@ async def platform_list_agent_channels(
                     "status": b.connection_status,
                     "is_active": b.is_active,
                     "connection_mode": b.connection_mode,
+                    "slack_bot_user_id": b.slack_bot_user_id,
                 }
                 for b in slack_bots
             ],

--- a/api/src/services/agents/internal_tools/slack_tools.py
+++ b/api/src/services/agents/internal_tools/slack_tools.py
@@ -305,6 +305,7 @@ async def internal_slack_read_channel_messages(
             messages.append(
                 {
                     "text": msg.get("text", ""),
+                    "user_id": user_id,
                     "user_name": sender_name,
                     "user_display_name": display_name,
                     "is_bot": is_bot_msg,
@@ -384,6 +385,7 @@ async def internal_slack_read_thread(
             messages.append(
                 {
                     "text": msg.get("text", ""),
+                    "user_id": user_id,
                     "user_name": user.get("name"),
                     "timestamp": msg.get("ts"),
                     "is_parent": msg.get("ts") == thread_ts,
@@ -610,6 +612,7 @@ async def internal_slack_search_messages(
             matches.append(
                 {
                     "text": match.get("text", ""),
+                    "user_id": match.get("user", ""),
                     "username": match.get("username", ""),
                     "channel_name": match.get("channel", {}).get("name", ""),
                     "channel_id": match.get("channel", {}).get("id", ""),
@@ -675,6 +678,93 @@ async def internal_slack_add_reaction(
         return {"success": False, "error": str(e)}
     except Exception as e:
         logger.error(f"Error adding reaction: {e}", exc_info=True)
+        return {"success": False, "error": str(e)}
+
+
+async def internal_slack_find_user(
+    query: str,
+    runtime_context: dict[str, Any] | None = None,
+    config: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """
+    Look up a Slack user's ID by name, display name, or email.
+
+    Slack mentions (<@USER_ID> to tag someone) and internal_slack_send_dm both need the
+    person's Slack user ID (e.g. "U0123ABC"), not their name — use this tool first whenever
+    you only know a person's name and need to tag or DM them.
+
+    Args:
+        query: Name, display name, or email address to search for
+        runtime_context: Runtime context from agent execution
+        config: Config dict with _tool_name
+
+    Returns:
+        On a single match: {"success": True, "user_id": ..., "name": ..., "display_name": ...,
+        "email": ...}. On multiple matches: {"success": True, "multiple_matches": True,
+        "candidates": [...]} — ask the user to clarify which one. On no match: {"success": False,
+        "error": ...}.
+    """
+    try:
+        client = await _get_slack_client(runtime_context, config)
+        if not client:
+            return {"success": False, "error": "No Slack connection available"}
+
+        query_stripped = query.strip()
+
+        if "@" in query_stripped and " " not in query_stripped:
+            try:
+                response = await client.users_lookupByEmail(email=query_stripped)
+                user = response.get("user", {})
+                profile = user.get("profile", {})
+                return {
+                    "success": True,
+                    "user_id": user.get("id"),
+                    "name": user.get("real_name") or user.get("name"),
+                    "display_name": profile.get("display_name", ""),
+                    "email": profile.get("email", ""),
+                }
+            except SlackApiError:
+                pass  # Not an email, or lookup failed — fall through to name search
+
+        query_lower = query_stripped.lower().lstrip("@")
+        exact_matches: list[dict[str, Any]] = []
+        partial_matches: list[dict[str, Any]] = []
+        cursor = None
+        while True:
+            response = await client.users_list(cursor=cursor, limit=200)
+            for user in response.get("members", []):
+                if user.get("is_bot") or user.get("deleted") or user.get("id") == "USLACKBOT":
+                    continue
+                profile = user.get("profile", {})
+                names_lower = [
+                    n.lower() for n in (user.get("real_name"), user.get("name"), profile.get("display_name")) if n
+                ]
+                entry = {
+                    "user_id": user.get("id"),
+                    "name": user.get("real_name") or user.get("name"),
+                    "display_name": profile.get("display_name", ""),
+                    "email": profile.get("email", ""),
+                }
+                if query_lower in names_lower:
+                    exact_matches.append(entry)
+                elif any(query_lower in n for n in names_lower):
+                    partial_matches.append(entry)
+            cursor = response.get("response_metadata", {}).get("next_cursor") or None
+            if not cursor:
+                break
+
+        matches = exact_matches or partial_matches
+        if not matches:
+            return {"success": False, "error": f"No Slack user found matching '{query}'"}
+        if len(matches) == 1:
+            return {"success": True, **matches[0]}
+        return {"success": True, "multiple_matches": True, "candidates": matches[:10]}
+
+    except SlackApiError as e:
+        logger.error(f"Slack API error in find_user: {e}", exc_info=True)
+        return {"success": False, "error": str(e)}
+    except Exception as e:
+        logger.error(f"Error finding user: {e}", exc_info=True)
         return {"success": False, "error": str(e)}
 
 

--- a/api/src/services/agents/tool_registrations/platform_tools_registry.py
+++ b/api/src/services/agents/tool_registrations/platform_tools_registry.py
@@ -707,7 +707,7 @@ def register_platform_tools(registry) -> None:
             "then collect the Bot Token (xoxb-...) and App Token (xapp-...) before calling this. "
             "For Event Mode, collect the Signing Secret instead of the App Token. "
             "The result includes slack_bot_user_id (Slack's own user id for this bot) — "
-            "use f\"<@{slack_bot_user_id}>\" in a message to @-mention this bot from another agent's bot."
+            'use f"<@{slack_bot_user_id}>" in a message to @-mention this bot from another agent\'s bot.'
         ),
         parameters={
             "type": "object",
@@ -764,7 +764,7 @@ def register_platform_tools(registry) -> None:
             "List all Slack and Telegram bots connected to a given agent. "
             "Use this to check which channels an agent is available on, or to find bot_ids before disconnecting. "
             "Each Slack entry includes slack_bot_user_id — to have one agent's bot @-mention another "
-            "agent's bot, call this for the target agent and embed f\"<@{slack_bot_user_id}>\" in the message text."
+            'agent\'s bot, call this for the target agent and embed f"<@{slack_bot_user_id}>" in the message text.'
         ),
         parameters={
             "type": "object",

--- a/api/src/services/agents/tool_registrations/platform_tools_registry.py
+++ b/api/src/services/agents/tool_registrations/platform_tools_registry.py
@@ -705,7 +705,9 @@ def register_platform_tools(registry) -> None:
             "Can target any agent by name, or 'platform_engineer_agent' to connect the PE itself. "
             "Guide the user to create a Slack app at api.slack.com/apps, enable Socket Mode, "
             "then collect the Bot Token (xoxb-...) and App Token (xapp-...) before calling this. "
-            "For Event Mode, collect the Signing Secret instead of the App Token."
+            "For Event Mode, collect the Signing Secret instead of the App Token. "
+            "The result includes slack_bot_user_id (Slack's own user id for this bot) — "
+            "use f\"<@{slack_bot_user_id}>\" in a message to @-mention this bot from another agent's bot."
         ),
         parameters={
             "type": "object",
@@ -760,7 +762,9 @@ def register_platform_tools(registry) -> None:
         name="platform_list_agent_channels",
         description=(
             "List all Slack and Telegram bots connected to a given agent. "
-            "Use this to check which channels an agent is available on, or to find bot_ids before disconnecting."
+            "Use this to check which channels an agent is available on, or to find bot_ids before disconnecting. "
+            "Each Slack entry includes slack_bot_user_id — to have one agent's bot @-mention another "
+            "agent's bot, call this for the target agent and embed f\"<@{slack_bot_user_id}>\" in the message text."
         ),
         parameters={
             "type": "object",

--- a/api/src/services/agents/tool_registrations/slack_tools_registry.py
+++ b/api/src/services/agents/tool_registrations/slack_tools_registry.py
@@ -21,6 +21,7 @@ def register_slack_tools(registry):
     from src.services.agents.internal_tools.slack_tools import (
         internal_slack_add_reaction,
         internal_slack_create_channel,
+        internal_slack_find_user,
         internal_slack_join_channel,
         internal_slack_list_channels,
         internal_slack_post_blocks,
@@ -37,6 +38,14 @@ def register_slack_tools(registry):
         runtime_context = config.get("_runtime_context") if config else None
         return await internal_slack_list_channels(
             include_private=kwargs.get("include_private", False), runtime_context=runtime_context, config=config
+        )
+
+    async def internal_slack_find_user_wrapper(config: dict[str, Any] | None = None, **kwargs):
+        runtime_context = config.get("_runtime_context") if config else None
+        return await internal_slack_find_user(
+            query=kwargs.get("query"),
+            runtime_context=runtime_context,
+            config=config,
         )
 
     async def internal_slack_read_channel_messages_wrapper(config: dict[str, Any] | None = None, **kwargs):
@@ -172,6 +181,24 @@ def register_slack_tools(registry):
     )
 
     registry.register_tool(
+        name="internal_slack_find_user",
+        description=(
+            "Look up a Slack user's ID by name, display name, or email. Slack mentions "
+            "(<@USER_ID> to tag someone) and internal_slack_send_dm both require the person's "
+            "Slack user ID, not their name — call this first whenever you only know a name and "
+            "need to tag or DM them. Returns multiple_matches with candidates if the name is ambiguous."
+        ),
+        parameters={
+            "type": "object",
+            "properties": {
+                "query": {"type": "string", "description": "Name, display name, or email to search for"},
+            },
+            "required": ["query"],
+        },
+        function=internal_slack_find_user_wrapper,
+    )
+
+    registry.register_tool(
         name="internal_slack_read_thread",
         description="Read all messages in a specific thread. Use this when you see a thread with replies and want to understand the full conversation context before responding.",
         parameters={
@@ -187,7 +214,13 @@ def register_slack_tools(registry):
 
     registry.register_tool(
         name="internal_slack_send_message",
-        description="Send a message to a Slack channel or thread. Only call this tool when the user explicitly asks you to send or post a message to a specific channel or thread. Do not call this tool to echo, summarize, or follow up on a response you have already given.",
+        description=(
+            "Send a message to a Slack channel or thread. Only call this tool when the user explicitly "
+            "asks you to send or post a message to a specific channel or thread. Do not call this tool "
+            "to echo, summarize, or follow up on a response you have already given. To @-mention/tag a "
+            'person or another bot, embed <@USER_ID> in the text (e.g. "<@U0123ABC> please review") — '
+            "if you only know their name, call internal_slack_find_user first to resolve it to an ID."
+        ),
         parameters={
             "type": "object",
             "properties": {
@@ -263,7 +296,10 @@ def register_slack_tools(registry):
             "properties": {
                 "user_id": {
                     "type": "string",
-                    "description": "Slack user ID (e.g., 'U1234567890'). This is the unique identifier for the user, not their display name.",
+                    "description": (
+                        "Slack user ID (e.g., 'U1234567890'). This is the unique identifier for the user, "
+                        "not their display name — call internal_slack_find_user first if you only have a name."
+                    ),
                 },
                 "text": {"type": "string", "description": "Message text to send to the user"},
                 "report_back_channel_id": {
@@ -298,7 +334,9 @@ def register_slack_tools(registry):
             "returned by internal_generate_infographic (uploaded to S3). "
             "If S3 is not configured, use internal_slack_upload_file with svg_content instead.\n\n"
             "Other useful block types: section (text), divider, context (small text), "
-            "actions (buttons), header (bold title)."
+            "actions (buttons), header (bold title).\n\n"
+            'To @-mention/tag a person or bot inside block text, embed <@USER_ID> (e.g. "<@U0123ABC>") — '
+            "call internal_slack_find_user first if you only know their name."
         ),
         parameters={
             "type": "object",
@@ -400,4 +438,4 @@ def register_slack_tools(registry):
         function=internal_slack_create_channel_wrapper,
     )
 
-    logger.info("Registered 11 Slack tools")
+    logger.info("Registered 12 Slack tools")

--- a/api/src/services/slack/slack_bot_manager.py
+++ b/api/src/services/slack/slack_bot_manager.py
@@ -11,7 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from ...config.redis import get_redis
 from ...models.agent import Agent
 from ...models.slack_bot import SlackBot
-from ...services.agents.security import encrypt_value
+from ...services.agents.security import decrypt_value, encrypt_value
 from ...services.bot_worker.bot_deployment_service import BotDeploymentService
 
 logger = logging.getLogger(__name__)
@@ -70,6 +70,10 @@ class SlackBotManager:
             if connection_mode == "event" and not signing_secret:
                 raise ValueError("Signing secret is required for Event Mode")
 
+            # Fetch the bot's own Slack user id (needed to @-mention this bot from
+            # another agent's bot) — best-effort, don't fail bot creation over it.
+            slack_bot_user_id = await self._fetch_bot_user_id(slack_bot_token)
+
             # Encrypt tokens
             encrypted_bot_token = encrypt_value(slack_bot_token)
             encrypted_app_token = encrypt_value(slack_app_token) if slack_app_token else None
@@ -86,6 +90,7 @@ class SlackBotManager:
                 slack_app_token=encrypted_app_token,
                 slack_workspace_id=slack_workspace_id,
                 slack_workspace_name=slack_workspace_name,
+                slack_bot_user_id=slack_bot_user_id,
                 connection_mode=connection_mode,
                 signing_secret=encrypted_signing_secret,
                 is_active=True,
@@ -111,6 +116,23 @@ class SlackBotManager:
             await self.db_session.rollback()
             logger.error(f"Failed to create Slack bot: {str(e)}")
             raise
+
+    async def _fetch_bot_user_id(self, slack_bot_token: str) -> str | None:
+        """Look up this bot's own Slack user id via auth.test, for @-mention support.
+
+        Best-effort: returns None (rather than raising) on any Slack API error so a
+        bad/rate-limited call never blocks bot creation.
+        """
+        from slack_sdk.errors import SlackApiError
+        from slack_sdk.web.async_client import AsyncWebClient
+
+        try:
+            client = AsyncWebClient(token=slack_bot_token)
+            response = await client.auth_test()
+            return response.get("user_id")
+        except SlackApiError as e:
+            logger.warning(f"auth.test failed while fetching bot user id: {e}")
+            return None
 
     def _generate_webhook_url(self, bot_id: UUID) -> str:
         """Generate the webhook URL for Event Mode.
@@ -188,6 +210,7 @@ class SlackBotManager:
 
             if slack_bot_token is not None:
                 slack_bot.slack_bot_token = encrypt_value(slack_bot_token)
+                slack_bot.slack_bot_user_id = await self._fetch_bot_user_id(slack_bot_token)
 
             if slack_app_token is not None:
                 slack_bot.slack_app_token = encrypt_value(slack_app_token)
@@ -324,6 +347,13 @@ class SlackBotManager:
                 if not slack_bot.webhook_url:
                     slack_bot.webhook_url = self._generate_webhook_url(bot_id)
 
+                # Backfill bot_user_id for bots created before that field existed —
+                # Event Mode has no Socket connection step to piggyback this on.
+                if not slack_bot.slack_bot_user_id:
+                    slack_bot.slack_bot_user_id = await self._fetch_bot_user_id(
+                        decrypt_value(slack_bot.slack_bot_token)
+                    )
+
                 await self.db_session.commit()
                 logger.info(f"Event Mode Slack bot {bot_id} marked as connected")
                 return True
@@ -398,6 +428,10 @@ class SlackBotManager:
                 # Event Mode: Just refresh connection status
                 slack_bot.connection_status = "connected"
                 slack_bot.last_connected_at = datetime.utcnow()
+                if not slack_bot.slack_bot_user_id:
+                    slack_bot.slack_bot_user_id = await self._fetch_bot_user_id(
+                        decrypt_value(slack_bot.slack_bot_token)
+                    )
                 await self.db_session.commit()
                 logger.info(f"Event Mode Slack bot {bot_id} restarted (refreshed status)")
                 return True

--- a/api/src/services/slack/slack_event_service.py
+++ b/api/src/services/slack/slack_event_service.py
@@ -142,6 +142,7 @@ class SlackEventService:
             thread_ts=thread_ts,
             client=client,
             say=None,  # Event mode uses client.chat_postMessage
+            is_bot_sender=bool(event.get("bot_id")),
         )
 
     async def _handle_message_event(self, slack_bot: SlackBot, event: dict[str, Any], payload: dict[str, Any]) -> None:

--- a/api/src/services/slack/slack_message_handler.py
+++ b/api/src/services/slack/slack_message_handler.py
@@ -266,7 +266,7 @@ class SlackMessageHandler:
                 channel_name = channel_id
 
             # Remove bot mention from text if present
-            clean_text = self._remove_bot_mention(text, slack_bot.slack_app_id)
+            clean_text = self._remove_bot_mention(text, slack_bot.slack_bot_user_id)
 
             logger.info(f"Slack message: Channel: #{channel_name} (ID: {channel_id}), Message TS: {message_ts}")
 
@@ -1069,11 +1069,17 @@ class SlackMessageHandler:
 
         return {"type": "context", "elements": parts[:10]}
 
-    def _remove_bot_mention(self, text: str, app_id: str) -> str:
-        """Remove bot mention from message text."""
+    def _remove_bot_mention(self, text: str, bot_user_id: str | None) -> str:
+        """Remove this bot's own @-mention from message text.
+
+        Slack's <@...> mention syntax embeds the bot's Slack *user* id (U.../B...),
+        not its App ID — bot_user_id must be SlackBot.slack_bot_user_id, not slack_app_id.
+        """
+        if not bot_user_id:
+            return text.strip()
         import re
 
-        pattern = f"<@{app_id}>"
+        pattern = f"<@{bot_user_id}>"
         return re.sub(pattern, "", text).strip()
 
     async def _extract_user_mentions(self, text: str, client: AsyncWebClient) -> list[dict[str, str]]:

--- a/api/src/services/slack/slack_message_handler.py
+++ b/api/src/services/slack/slack_message_handler.py
@@ -113,6 +113,7 @@ class SlackMessageHandler:
         thread_ts: str | None,
         client: AsyncWebClient,
         say: Callable[..., Any] | None = None,
+        is_bot_sender: bool = False,
     ) -> str | None:
         """
         Handle incoming Slack message and generate agent response.
@@ -126,9 +127,14 @@ class SlackMessageHandler:
             thread_ts: Thread timestamp (for threaded conversations)
             client: Slack web client
             say: Optional Slack say function (for Socket Mode). If None, uses client.chat_postMessage
+            is_bot_sender: True if this message/mention was authored by another Slack bot
+                (e.g. another Synkora agent), not a human. When True, the agent is told it
+                may skip replying, and a genuinely empty response is left unanswered instead
+                of being replaced with a filler message — this is what lets two bots have a
+                real back-and-forth without being forced to always have the last word.
 
         Returns:
-            The agent's response text, or None on error
+            The agent's response text, or None on error / no reply needed
         """
         try:
             # Block Slack Connect (externally-shared) channels unless explicitly allowed.
@@ -277,6 +283,18 @@ class SlackMessageHandler:
             # Slack context (channel, user) is passed via shared_state for tool use.
             context_message = clean_text
 
+            if is_bot_sender:
+                # Give the agent explicit permission to stay silent — without this, a
+                # genuinely empty response below is treated as an error and gets a filler
+                # reply substituted, which would force every bot-to-bot exchange to keep
+                # going forever. The agent decides per-message whether a reply adds value.
+                context_message = (
+                    f"[This message is from another bot/agent ({user_name}), not a human. "
+                    "Only reply if a response is genuinely needed — to answer a direct question, "
+                    "correct something, or take an action. If no reply is needed, respond with "
+                    "nothing at all rather than acknowledging or restating.]\n\n" + clean_text
+                )
+
             # Slack-specific metadata to attach to the user message. The actual message row
             # is saved by ChatStreamService.stream_agent_response() below (via
             # user_message_metadata) — saving it here too would create a duplicate row.
@@ -423,11 +441,20 @@ class SlackMessageHandler:
                     pass
 
             agent_response = "".join(response_chunks)
-
-            # Handle empty response. ChatStreamService only persists an assistant message
-            # when it actually produced content, so this fallback case is the one situation
-            # where we still need to save it ourselves below.
             response_was_empty = not agent_response or not agent_response.strip()
+
+            if response_was_empty and is_bot_sender:
+                # The agent deliberately chose not to reply to another bot's message — respect
+                # that instead of forcing a filler response, so bot-to-bot exchanges can end
+                # naturally (only replying when something actually needs saying) rather than
+                # ping-ponging forever.
+                logger.info(f"Agent chose not to reply to bot-authored mention in channel {channel_id}")
+                await status_service.clear_status(channel_id, effective_thread_ts)
+                return None
+
+            # Handle empty response for a human-facing turn. ChatStreamService only persists
+            # an assistant message when it actually produced content, so this fallback case is
+            # the one situation where we still need to save it ourselves below.
             if response_was_empty:
                 logger.warning("Agent returned empty response, using fallback message")
                 agent_response = "Done! I've processed your request."

--- a/api/src/services/slack/slack_socket_service.py
+++ b/api/src/services/slack/slack_socket_service.py
@@ -60,18 +60,21 @@ class SlackSocketService:
             # Create Slack app
             app = AsyncApp(token=bot_token)
 
-            # Auto-detect workspace info if not set
-            if not slack_bot.slack_workspace_id:
+            # Auto-detect workspace info and this bot's own Slack user id (for @-mention
+            # support) if not already set — backfills bots created before that field existed.
+            if not slack_bot.slack_workspace_id or not slack_bot.slack_bot_user_id:
                 try:
                     client = AsyncWebClient(token=bot_token)
                     auth_response = await client.auth_test()
                     slack_bot.slack_workspace_id = auth_response["team_id"]
                     slack_bot.slack_workspace_name = auth_response["team"]
+                    slack_bot.slack_bot_user_id = auth_response.get("user_id")
                     logger.info(
-                        f"Auto-detected workspace: {slack_bot.slack_workspace_name} ({slack_bot.slack_workspace_id})"
+                        f"Auto-detected workspace: {slack_bot.slack_workspace_name} ({slack_bot.slack_workspace_id}), "
+                        f"bot_user_id: {slack_bot.slack_bot_user_id}"
                     )
                 except Exception as e:
-                    logger.warning(f"Failed to auto-detect workspace info: {str(e)}")
+                    logger.warning(f"Failed to auto-detect workspace/bot user info: {str(e)}")
 
             # Register event handlers
             self._register_event_handlers(app, slack_bot)

--- a/api/src/services/slack/slack_socket_service.py
+++ b/api/src/services/slack/slack_socket_service.py
@@ -142,7 +142,7 @@ class SlackSocketService:
 
         @app.event("app_mention")
         async def handle_app_mention(event, say, client):
-            """Handle @mentions of the bot."""
+            """Handle @mentions of the bot — including mentions from another agent's bot."""
             await self._handle_message(
                 slack_bot=slack_bot,
                 channel_id=event["channel"],
@@ -152,6 +152,7 @@ class SlackSocketService:
                 thread_ts=event.get("thread_ts"),
                 say=say,
                 client=client,
+                is_bot_sender=bool(event.get("bot_id")),
             )
 
         @app.event("message")
@@ -242,6 +243,7 @@ class SlackSocketService:
         thread_ts: str | None,
         say,
         client: AsyncWebClient,
+        is_bot_sender: bool = False,
     ) -> None:
         """Delegate message handling to the shared SlackMessageHandler."""
         handler = SlackMessageHandler(self.db_session, self.agent_manager)
@@ -254,6 +256,7 @@ class SlackSocketService:
             thread_ts=thread_ts,
             client=client,
             say=say,
+            is_bot_sender=is_bot_sender,
         )
 
     async def _handle_app_home_opened(self, slack_bot: SlackBot, event: dict, client: AsyncWebClient) -> None:

--- a/api/tests/unit/services/agents/internal_tools/test_platform_tools.py
+++ b/api/tests/unit/services/agents/internal_tools/test_platform_tools.py
@@ -10,11 +10,13 @@ from src.services.agents.internal_tools.platform_tools import (
     platform_attach_knowledge_base,
     platform_attach_mcp_server,
     platform_check_integration,
+    platform_create_agent,
     platform_disable_agent_autonomous,
     platform_get_agent_autonomous,
     platform_list_database_connections,
     platform_list_knowledge_bases,
     platform_set_agent_autonomous,
+    platform_update_agent,
 )
 
 
@@ -406,3 +408,167 @@ class TestPlatformCheckIntegrationSlack:
         result = await platform_check_integration(provider="slack", runtime_context=runtime_context)
 
         assert result["connected"] is False
+
+
+class TestPlatformCreateAgentSlug:
+    """platform_create_agent must always set Agent.slug — the chat-builder creation path
+    previously only set agent_name, leaving slug NULL and breaking /agents/<slug>/* routing."""
+
+    @pytest.fixture
+    def runtime_context(self):
+        ctx = MagicMock()
+        ctx.tenant_id = uuid4()
+        ctx.user_id = uuid4()
+        ctx.db_session = AsyncMock(spec=AsyncSession)
+        ctx.conversation_id = None
+        return ctx
+
+    @staticmethod
+    def _no_match_result():
+        result = MagicMock()
+        result.scalar_one_or_none.return_value = None
+        return result
+
+    @pytest.mark.asyncio
+    async def test_generates_slug_from_name(self, runtime_context):
+        db = runtime_context.db_session
+        db.add = MagicMock()
+        db.flush = AsyncMock()
+        db.commit = AsyncMock()
+        db.execute = AsyncMock(side_effect=[self._no_match_result(), self._no_match_result()])
+
+        with patch("src.services.billing.plan_restriction_service.PlanRestrictionService") as MockRestriction:
+            MockRestriction.return_value.enforce_agent_limit = AsyncMock()
+
+            result = await platform_create_agent(
+                name="Product Agent!",
+                description="desc",
+                system_prompt="prompt",
+                llm_provider="openai",
+                llm_model="gpt-4o",
+                api_key="sk-test",
+                runtime_context=runtime_context,
+            )
+
+        assert result["success"] is True
+        assert result["slug"] == "product-agent"
+        created_agent = db.add.call_args_list[0].args[0]
+        assert created_agent.slug == "product-agent"
+
+    @pytest.mark.asyncio
+    async def test_appends_suffix_on_slug_collision(self, runtime_context):
+        """Agent.slug is unique across ALL tenants (unlike agent_name, per-tenant only) —
+        a collision must be disambiguated rather than raising an IntegrityError later."""
+        db = runtime_context.db_session
+        db.add = MagicMock()
+        db.flush = AsyncMock()
+        db.commit = AsyncMock()
+
+        slug_conflict = MagicMock()
+        slug_conflict.scalar_one_or_none.return_value = MagicMock()  # another agent already has this slug
+        db.execute = AsyncMock(side_effect=[self._no_match_result(), slug_conflict])
+
+        with patch("src.services.billing.plan_restriction_service.PlanRestrictionService") as MockRestriction:
+            MockRestriction.return_value.enforce_agent_limit = AsyncMock()
+
+            result = await platform_create_agent(
+                name="Product Agent",
+                description="desc",
+                system_prompt="prompt",
+                llm_provider="openai",
+                llm_model="gpt-4o",
+                api_key="sk-test",
+                runtime_context=runtime_context,
+            )
+
+        assert result["success"] is True
+        assert result["slug"] != "product-agent"
+        assert result["slug"].startswith("product-agent-")
+
+
+class TestPlatformUpdateAgentSlug:
+    """platform_update_agent's slug param lets Platform Engineer backfill agents created
+    before slug generation existed, but only while the slug is still unset — slugs are
+    otherwise immutable (mirrors the REST update endpoint's immutable-slug rule)."""
+
+    @pytest.fixture
+    def runtime_context(self):
+        ctx = MagicMock()
+        ctx.tenant_id = uuid4()
+        ctx.user_id = uuid4()
+        ctx.db_session = AsyncMock(spec=AsyncSession)
+        return ctx
+
+    @pytest.fixture
+    def mock_agent(self):
+        agent = MagicMock()
+        agent.id = uuid4()
+        agent.agent_name = "product_agent"
+        agent.slug = None
+        agent.status = "ACTIVE"
+        return agent
+
+    @staticmethod
+    def _result_for(value):
+        result = MagicMock()
+        result.scalar_one_or_none.return_value = value
+        return result
+
+    @pytest.mark.asyncio
+    async def test_sets_slug_when_currently_unset(self, runtime_context, mock_agent):
+        db = runtime_context.db_session
+        db.commit = AsyncMock()
+
+        existing_llm = MagicMock(api_key="enc-key", provider="openai", model_name="gpt-4o", api_base=None)
+        existing_llm.additional_params = {}
+        db.execute = AsyncMock(
+            side_effect=[
+                self._result_for(mock_agent),  # agent lookup by agent_name
+                self._result_for(None),  # slug uniqueness check: no conflict
+                self._result_for(existing_llm),  # existing AgentLLMConfig already has an api_key
+            ]
+        )
+
+        result = await platform_update_agent(
+            agent_name="product_agent", slug="  Product Agent!! ", runtime_context=runtime_context
+        )
+
+        assert result["success"] is True
+        assert result["slug"] == "product-agent"
+        assert mock_agent.slug == "product-agent"
+        db.commit.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_refuses_to_change_an_already_set_slug(self, runtime_context, mock_agent):
+        mock_agent.slug = "already-set"
+        db = runtime_context.db_session
+        db.commit = AsyncMock()
+        db.execute = AsyncMock(return_value=self._result_for(mock_agent))
+
+        result = await platform_update_agent(
+            agent_name="product_agent", slug="new-slug", runtime_context=runtime_context
+        )
+
+        assert result["success"] is False
+        assert "already-set" in result["message"]
+        assert mock_agent.slug == "already-set"  # unchanged
+        db.commit.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_refuses_slug_already_used_by_another_agent(self, runtime_context, mock_agent):
+        db = runtime_context.db_session
+        db.commit = AsyncMock()
+        db.execute = AsyncMock(
+            side_effect=[
+                self._result_for(mock_agent),  # agent lookup
+                self._result_for(MagicMock()),  # slug taken by a different agent
+            ]
+        )
+
+        result = await platform_update_agent(
+            agent_name="product_agent", slug="taken-slug", runtime_context=runtime_context
+        )
+
+        assert result["success"] is False
+        assert mock_agent.slug is None  # left untouched
+        db.commit.assert_not_awaited()

--- a/api/tests/unit/services/agents/internal_tools/test_slack_tools.py
+++ b/api/tests/unit/services/agents/internal_tools/test_slack_tools.py
@@ -123,6 +123,197 @@ class TestInternalSlackReadChannelMessages:
 
             assert result["success"] is False
 
+    @pytest.mark.asyncio
+    async def test_messages_include_raw_slack_user_id(self):
+        """The raw Slack user id must be surfaced so agents can @-mention someone from
+        recent history — previously it was fetched only to resolve a display name, then
+        discarded, leaving no way to construct a <@USER_ID> mention."""
+        from src.services.agents.internal_tools.slack_tools import internal_slack_read_channel_messages
+
+        mock_slack_client = AsyncMock()
+        mock_slack_client.conversations_history.return_value = {
+            "messages": [
+                {"text": "hi there", "user": "U0HUMAN", "ts": "1.1"},
+            ]
+        }
+        mock_slack_client.conversations_info.return_value = {"channel": {"name": "general"}}
+        mock_slack_client.users_info.return_value = {"user": {"real_name": "Jane Doe", "profile": {}}}
+
+        with patch(
+            "src.services.agents.internal_tools.slack_tools._get_slack_client", new_callable=AsyncMock
+        ) as mock_get:
+            mock_get.return_value = mock_slack_client
+
+            result = await internal_slack_read_channel_messages(channel_id="C123", runtime_context={})
+
+            assert result["success"] is True
+            assert result["messages"][0]["user_id"] == "U0HUMAN"
+            assert result["messages"][0]["user_name"] == "Jane Doe"
+
+
+class TestInternalSlackFindUser:
+    """Tests for internal_slack_find_user function."""
+
+    @pytest.mark.asyncio
+    async def test_returns_error_without_slack_client(self):
+        from src.services.agents.internal_tools.slack_tools import internal_slack_find_user
+
+        with patch(
+            "src.services.agents.internal_tools.slack_tools._get_slack_client", new_callable=AsyncMock
+        ) as mock_get:
+            mock_get.return_value = None
+
+            result = await internal_slack_find_user(query="Jane", runtime_context={})
+
+            assert result["success"] is False
+
+    @pytest.mark.asyncio
+    async def test_resolves_by_email(self):
+        from src.services.agents.internal_tools.slack_tools import internal_slack_find_user
+
+        mock_slack_client = AsyncMock()
+        mock_slack_client.users_lookupByEmail.return_value = {
+            "user": {
+                "id": "U0JANE",
+                "real_name": "Jane Doe",
+                "profile": {"display_name": "jdoe", "email": "jane@example.com"},
+            }
+        }
+
+        with patch(
+            "src.services.agents.internal_tools.slack_tools._get_slack_client", new_callable=AsyncMock
+        ) as mock_get:
+            mock_get.return_value = mock_slack_client
+
+            result = await internal_slack_find_user(query="jane@example.com", runtime_context={})
+
+            assert result["success"] is True
+            assert result["user_id"] == "U0JANE"
+            mock_slack_client.users_lookupByEmail.assert_called_once_with(email="jane@example.com")
+
+    @pytest.mark.asyncio
+    async def test_resolves_single_exact_name_match(self):
+        from src.services.agents.internal_tools.slack_tools import internal_slack_find_user
+
+        mock_slack_client = AsyncMock()
+        mock_slack_client.users_list.return_value = {
+            "members": [
+                {
+                    "id": "U0JANE",
+                    "is_bot": False,
+                    "deleted": False,
+                    "real_name": "Jane Doe",
+                    "name": "jane",
+                    "profile": {"display_name": "jdoe", "email": "jane@example.com"},
+                },
+                {
+                    "id": "U0JOHN",
+                    "is_bot": False,
+                    "deleted": False,
+                    "real_name": "John Smith",
+                    "name": "john",
+                    "profile": {"display_name": "jsmith", "email": "john@example.com"},
+                },
+            ],
+            "response_metadata": {"next_cursor": ""},
+        }
+
+        with patch(
+            "src.services.agents.internal_tools.slack_tools._get_slack_client", new_callable=AsyncMock
+        ) as mock_get:
+            mock_get.return_value = mock_slack_client
+
+            result = await internal_slack_find_user(query="Jane Doe", runtime_context={})
+
+            assert result["success"] is True
+            assert result["user_id"] == "U0JANE"
+            assert "multiple_matches" not in result
+
+    @pytest.mark.asyncio
+    async def test_ambiguous_partial_match_returns_candidates(self):
+        from src.services.agents.internal_tools.slack_tools import internal_slack_find_user
+
+        mock_slack_client = AsyncMock()
+        mock_slack_client.users_list.return_value = {
+            "members": [
+                {
+                    "id": "U0JANE",
+                    "is_bot": False,
+                    "deleted": False,
+                    "real_name": "Jane Anderson",
+                    "name": "jane.a",
+                    "profile": {},
+                },
+                {
+                    "id": "U0JANET",
+                    "is_bot": False,
+                    "deleted": False,
+                    "real_name": "Janet Baker",
+                    "name": "janet",
+                    "profile": {},
+                },
+            ],
+            "response_metadata": {"next_cursor": ""},
+        }
+
+        with patch(
+            "src.services.agents.internal_tools.slack_tools._get_slack_client", new_callable=AsyncMock
+        ) as mock_get:
+            mock_get.return_value = mock_slack_client
+
+            result = await internal_slack_find_user(query="jane", runtime_context={})
+
+            assert result["success"] is True
+            assert result["multiple_matches"] is True
+            assert {c["user_id"] for c in result["candidates"]} == {"U0JANE", "U0JANET"}
+
+    @pytest.mark.asyncio
+    async def test_no_match_returns_failure(self):
+        from src.services.agents.internal_tools.slack_tools import internal_slack_find_user
+
+        mock_slack_client = AsyncMock()
+        mock_slack_client.users_list.return_value = {"members": [], "response_metadata": {"next_cursor": ""}}
+
+        with patch(
+            "src.services.agents.internal_tools.slack_tools._get_slack_client", new_callable=AsyncMock
+        ) as mock_get:
+            mock_get.return_value = mock_slack_client
+
+            result = await internal_slack_find_user(query="Nobody", runtime_context={})
+
+            assert result["success"] is False
+
+    @pytest.mark.asyncio
+    async def test_skips_bots_and_deleted_users(self):
+        from src.services.agents.internal_tools.slack_tools import internal_slack_find_user
+
+        mock_slack_client = AsyncMock()
+        mock_slack_client.users_list.return_value = {
+            "members": [
+                {"id": "B0BOT", "is_bot": True, "deleted": False, "real_name": "Jane Bot", "name": "jane_bot"},
+                {"id": "U0GONE", "is_bot": False, "deleted": True, "real_name": "Jane Gone", "name": "jane_gone"},
+                {
+                    "id": "U0JANE",
+                    "is_bot": False,
+                    "deleted": False,
+                    "real_name": "Jane Doe",
+                    "name": "jane",
+                    "profile": {},
+                },
+            ],
+            "response_metadata": {"next_cursor": ""},
+        }
+
+        with patch(
+            "src.services.agents.internal_tools.slack_tools._get_slack_client", new_callable=AsyncMock
+        ) as mock_get:
+            mock_get.return_value = mock_slack_client
+
+            result = await internal_slack_find_user(query="jane", runtime_context={})
+
+            assert result["success"] is True
+            assert result["user_id"] == "U0JANE"
+
 
 class TestInternalSlackSendMessage:
     """Tests for internal_slack_send_message function."""

--- a/api/tests/unit/services/slack/test_slack_bot_manager.py
+++ b/api/tests/unit/services/slack/test_slack_bot_manager.py
@@ -95,6 +95,69 @@ class TestSlackBotManager:
             mock_db_session.refresh.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_create_bot_captures_bot_user_id(self, manager, mock_db_session):
+        """auth.test's user_id (Slack's own id for the bot) must be stored for @-mention support."""
+        with (
+            patch("src.services.slack.slack_bot_manager.encrypt_value", return_value="enc"),
+            patch(
+                "slack_sdk.web.async_client.AsyncWebClient.auth_test",
+                new=AsyncMock(return_value={"user_id": "U0BOTID"}),
+            ),
+        ):
+            result = await manager.create_bot(
+                agent_id=uuid4(),
+                tenant_id=uuid4(),
+                bot_name="New Bot",
+                slack_app_id="A123",
+                slack_bot_token="xoxb-token",
+                slack_app_token="xapp-token",
+            )
+
+        assert result.slack_bot_user_id == "U0BOTID"
+
+    @pytest.mark.asyncio
+    async def test_create_bot_bot_user_id_lookup_failure_does_not_block_creation(self, manager, mock_db_session):
+        """A Slack API error while fetching the bot's user id must not prevent bot creation."""
+        from slack_sdk.errors import SlackApiError
+
+        with (
+            patch("src.services.slack.slack_bot_manager.encrypt_value", return_value="enc"),
+            patch(
+                "slack_sdk.web.async_client.AsyncWebClient.auth_test",
+                new=AsyncMock(side_effect=SlackApiError("invalid_auth", response={"error": "invalid_auth"})),
+            ),
+        ):
+            result = await manager.create_bot(
+                agent_id=uuid4(),
+                tenant_id=uuid4(),
+                bot_name="New Bot",
+                slack_app_id="A123",
+                slack_bot_token="xoxb-bad-token",
+                slack_app_token="xapp-token",
+            )
+
+        assert isinstance(result, SlackBot)
+        assert result.slack_bot_user_id is None
+        mock_db_session.commit.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_update_bot_token_rotation_refreshes_bot_user_id(self, manager, mock_db_session, mock_slack_bot):
+        """Rotating a bot's token must re-fetch and store its (possibly new) bot_user_id."""
+        mock_db_session.get.return_value = mock_slack_bot
+        mock_slack_bot.slack_bot_user_id = "U0OLD"
+
+        with (
+            patch("src.services.slack.slack_bot_manager.encrypt_value", return_value="enc"),
+            patch(
+                "slack_sdk.web.async_client.AsyncWebClient.auth_test",
+                new=AsyncMock(return_value={"user_id": "U0NEW"}),
+            ),
+        ):
+            await manager.update_bot(bot_id=mock_slack_bot.id, slack_bot_token="new-token")
+
+        assert mock_slack_bot.slack_bot_user_id == "U0NEW"
+
+    @pytest.mark.asyncio
     async def test_create_bot_default_blocks_external_shared(self, manager, mock_db_session):
         with patch("src.services.slack.slack_bot_manager.encrypt_value", return_value="enc"):
             result = await manager.create_bot(

--- a/api/tests/unit/services/slack/test_slack_message_handler.py
+++ b/api/tests/unit/services/slack/test_slack_message_handler.py
@@ -1,6 +1,7 @@
 """Tests for SlackMessageHandler externally-shared-channel blocking."""
 
-from unittest.mock import AsyncMock, MagicMock
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
 import pytest
@@ -43,6 +44,21 @@ def mock_slack_bot():
 def mock_client():
     client = AsyncMock()
     return client
+
+
+class TestRemoveBotMention:
+    """_remove_bot_mention must strip using the bot's Slack *user* id, not its App ID —
+    Slack's <@...> mention syntax embeds the former, never the latter."""
+
+    def test_strips_matching_bot_user_id(self, handler):
+        assert handler._remove_bot_mention("<@U0BOTID> please review", "U0BOTID") == "please review"
+
+    def test_leaves_text_unchanged_when_bot_user_id_is_none(self, handler):
+        """Bots not yet backfilled with a slack_bot_user_id must not crash; text passes through."""
+        assert handler._remove_bot_mention("<@U0BOTID> hello", None) == "<@U0BOTID> hello"
+
+    def test_does_not_strip_a_different_users_mention(self, handler):
+        assert handler._remove_bot_mention("<@U0OTHER> hi <@U0BOTID>", "U0BOTID") == "<@U0OTHER> hi"
 
 
 class TestExternalSharedChannelBlock:
@@ -255,6 +271,101 @@ class TestAckReactionAndThinkingStatus:
 
         handler._get_or_create_conversation.assert_called_once()
         assert result is None  # generic error path returns None after RuntimeError
+
+
+class TestBotSenderReplyGating:
+    """Ping-pong between two Synkora bots is fine, but each bot must only reply when it
+    actually has something to say. When is_bot_sender=True: (1) the agent is told in-context
+    it may skip replying, and (2) a genuinely empty response is honored as "no reply" instead
+    of being replaced with a filler message. Human-facing messages are unaffected."""
+
+    @pytest.fixture
+    def wired_handler(self, handler, mock_client, mock_db_session):
+        """Wire handle_message's internals up to (mocked) agent/conversation/streaming seams
+        so execution reaches the empty-response branch instead of erroring out early."""
+        mock_client.conversations_info = AsyncMock(
+            return_value={"channel": {"is_ext_shared": False, "is_org_shared": False}}
+        )
+        mock_client.users_info = AsyncMock(return_value={"user": {"real_name": "OtherBot", "name": "otherbot"}})
+        mock_client.reactions_add = AsyncMock()
+        mock_client.api_call = AsyncMock(return_value={"ok": True})
+
+        handler._get_or_create_conversation = AsyncMock(
+            return_value=MagicMock(id=uuid4(), handoff_status=None, increment_message_count=MagicMock())
+        )
+        handler._fetch_thread_context = AsyncMock(return_value=[])
+        mock_db_session.get = AsyncMock(return_value=MagicMock(slug="test-agent", agent_name="test_agent"))
+
+        return handler
+
+    async def _run(self, wired_handler, mock_client, is_bot_sender, response_chunks):
+        captured_kwargs = {}
+
+        async def fake_stream(**kwargs):
+            captured_kwargs.update(kwargs)
+            for chunk in response_chunks:
+                yield f"data: {json.dumps({'type': 'chunk', 'content': chunk})}"
+
+        with (
+            patch(
+                "src.services.conversation_service.ConversationService.get_conversation_history_cached",
+                new=AsyncMock(return_value=[]),
+            ),
+            patch("src.services.agents.chat_stream_service.ChatStreamService") as MockChatStreamService,
+        ):
+            MockChatStreamService.return_value.stream_agent_response = fake_stream
+            result = await wired_handler.handle_message(
+                slack_bot=MagicMock(
+                    id=uuid4(), agent_id=uuid4(), tenant_id=uuid4(), created_by=None, slack_bot_user_id="U0BOTID"
+                ),
+                channel_id="C123",
+                user_id="U-BOT",
+                text="<@U0BOTID> hello",
+                message_ts="123.456",
+                thread_ts=None,
+                client=mock_client,
+                say=None,  # force the client.chat_postMessage path so we can assert on it
+                is_bot_sender=is_bot_sender,
+            )
+        return result, captured_kwargs
+
+    @pytest.mark.asyncio
+    async def test_bot_sender_empty_response_sends_nothing(self, wired_handler, mock_client):
+        result, _ = await self._run(wired_handler, mock_client, is_bot_sender=True, response_chunks=[])
+
+        assert result is None
+        mock_client.chat_postMessage.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_bot_sender_context_message_includes_permission_to_skip(self, wired_handler, mock_client):
+        _, captured_kwargs = await self._run(wired_handler, mock_client, is_bot_sender=True, response_chunks=["ok"])
+
+        sent_message = captured_kwargs["message"]
+        assert "from another bot/agent" in sent_message
+        assert "respond with" in sent_message
+        assert sent_message.endswith("hello")  # the mention itself is still stripped
+
+    @pytest.mark.asyncio
+    async def test_human_sender_context_message_has_no_bot_note(self, wired_handler, mock_client):
+        _, captured_kwargs = await self._run(wired_handler, mock_client, is_bot_sender=False, response_chunks=["ok"])
+
+        assert captured_kwargs["message"] == "hello"
+
+    @pytest.mark.asyncio
+    async def test_human_sender_empty_response_gets_filler_message(self, wired_handler, mock_client):
+        result, _ = await self._run(wired_handler, mock_client, is_bot_sender=False, response_chunks=[])
+
+        assert result == "Done! I've processed your request."
+        mock_client.chat_postMessage.assert_called_once()
+        assert mock_client.chat_postMessage.call_args.kwargs["text"] == "Done! I've processed your request."
+
+    @pytest.mark.asyncio
+    async def test_bot_sender_non_empty_response_still_sent(self, wired_handler, mock_client):
+        result, _ = await self._run(wired_handler, mock_client, is_bot_sender=True, response_chunks=["Thanks, done."])
+
+        assert result == "Thanks, done."
+        mock_client.chat_postMessage.assert_called_once()
+        assert mock_client.chat_postMessage.call_args.kwargs["text"] == "Thanks, done."
 
 
 class TestUploadDiagrams:

--- a/api/tests/unit/services/slack/test_slack_socket_service.py
+++ b/api/tests/unit/services/slack/test_slack_socket_service.py
@@ -162,7 +162,80 @@ class TestSlackSocketService:
                 thread_ts="ts1",
                 client=mock_client,
                 say=mock_say,
+                is_bot_sender=False,
             )
+
+    @pytest.mark.asyncio
+    async def test_handle_message_forwards_is_bot_sender_flag(self, service, mock_slack_bot, mock_db_session):
+        """_handle_message must forward an explicit is_bot_sender=True through to the handler."""
+        mock_client = MagicMock()
+        mock_say = AsyncMock()
+
+        with patch("src.services.slack.slack_socket_service.SlackMessageHandler") as MockHandler:
+            mock_handler_instance = AsyncMock()
+            MockHandler.return_value = mock_handler_instance
+
+            await service._handle_message(
+                slack_bot=mock_slack_bot,
+                channel_id="C1",
+                user_id="U1",
+                text="hello",
+                message_ts="123456.789",
+                thread_ts="ts1",
+                say=mock_say,
+                client=mock_client,
+                is_bot_sender=True,
+            )
+
+            mock_handler_instance.handle_message.assert_awaited_once_with(
+                slack_bot=mock_slack_bot,
+                channel_id="C1",
+                user_id="U1",
+                text="hello",
+                message_ts="123456.789",
+                thread_ts="ts1",
+                client=mock_client,
+                say=mock_say,
+                is_bot_sender=True,
+            )
+
+    @pytest.mark.asyncio
+    async def test_app_mention_sets_is_bot_sender_from_event_bot_id(self, service, mock_slack_bot):
+        """The registered app_mention handler must derive is_bot_sender from event['bot_id']."""
+        captured = {}
+
+        class FakeApp:
+            def event(self, name):
+                def decorator(fn):
+                    captured[name] = fn
+                    return fn
+
+                return decorator
+
+            def action(self, name):
+                def decorator(fn):
+                    return fn
+
+                return decorator
+
+        with patch.object(service, "_handle_message", new=AsyncMock()) as mock_handle_message:
+            service._register_event_handlers(FakeApp(), mock_slack_bot)
+
+            # A human mention (no bot_id) -> is_bot_sender=False
+            await captured["app_mention"](
+                event={"channel": "C1", "user": "U1", "text": "hi", "ts": "1.1"},
+                say=AsyncMock(),
+                client=MagicMock(),
+            )
+            assert mock_handle_message.await_args.kwargs["is_bot_sender"] is False
+
+            # A mention forwarded from another bot's message -> is_bot_sender=True
+            await captured["app_mention"](
+                event={"channel": "C1", "user": "U-BOT", "text": "<@U2> hi", "ts": "1.2", "bot_id": "B999"},
+                say=AsyncMock(),
+                client=MagicMock(),
+            )
+            assert mock_handle_message.await_args.kwargs["is_bot_sender"] is True
 
     @pytest.mark.asyncio
     async def test_handle_message_error_propagates(self, service, mock_slack_bot, mock_db_session):


### PR DESCRIPTION
## Summary
- Add `SlackBot.slack_bot_user_id` (Slack's own user id for the bot, distinct from our internal DB id) so one agent's bot can embed `<@bot_user_id>` in a message to @-mention another agent's bot.
- Captured via Slack's `auth.test`: on new bot creation, on token rotation, and on bot restart/reconnect (both Socket and Event mode) — so existing bots backfill this field automatically on their next restart, no token re-entry needed.
- `platform_create_slack_bot` and `platform_list_agent_channels` now surface `slack_bot_user_id`; Platform Engineer's tool schemas/system prompt explain how to use it for cross-bot mentions.
- Includes migration `20260824_0001_add_slack_bot_user_id`.

## Test plan
- [ ] Not verified locally (local env is missing deps to run the test suite — no fastapi installed, `uv sync` fails building `xmlsec`/`libxmlsec1` on this machine, docker-compose not running).
- [ ] To be tested directly in production after deploy: create/restart a Slack bot, confirm `slack_bot_user_id` gets populated, and confirm one agent's bot can `<@...>` mention another's in a message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)