### PR TITLE
fix: never send an empty message list to the LLM provider

### DIFF
--- a/api/src/services/agents/function_calling.py
+++ b/api/src/services/agents/function_calling.py
@@ -427,6 +427,13 @@ class FunctionCallingHandler:
                         if isinstance(rc, str) and rc:
                             entry["reasoning_content"] = rc
                     conversation_history.append(entry)
+            if len(conversation_history) == 1:
+                # Every message had empty/falsy content and got filtered out above, leaving
+                # only the system entry. Anthropic (and others) reject a messages array with
+                # no user/assistant turn at all ("at least one message is required") — never
+                # let that reach the provider.
+                logger.warning("All conversation turns had empty content; substituting a placeholder user message")
+                conversation_history.append({"role": "user", "content": "Hi!"})
             logger.info(f"📝 Using structured conversation: {len(messages)} messages passed to LLM")
         else:
             conversation_history = [{"role": "user", "content": prompt + pii_system_note}]

--- a/api/src/services/slack/slack_message_handler.py
+++ b/api/src/services/slack/slack_message_handler.py
@@ -274,6 +274,14 @@ class SlackMessageHandler:
             # Remove bot mention from text if present
             clean_text = self._remove_bot_mention(text, slack_bot.slack_bot_user_id)
 
+            if not clean_text.strip():
+                # A bare @mention with no other text (e.g. just "@bot"), or any other message
+                # that resolves to empty after stripping, must never be forwarded as-is: some
+                # tool-calling code paths silently drop an empty-content turn entirely, which
+                # can collapse the whole messages list to zero entries and get a 400 from the
+                # LLM provider ("at least one message is required").
+                clean_text = "Hi!"
+
             logger.info(f"Slack message: Channel: #{channel_name} (ID: {channel_id}), Message TS: {message_ts}")
 
             # The agent receives only the clean user text — no raw Slack metadata.

--- a/api/tests/unit/services/agents/test_function_calling.py
+++ b/api/tests/unit/services/agents/test_function_calling.py
@@ -237,6 +237,34 @@ class TestFunctionCallingHandler:
             # 3. Text content (final answer)
             assert any(c["type"] == "text" and c["content"] == "Final" for c in chunks)
 
+    @pytest.mark.asyncio
+    async def test_generate_with_functions_stream_never_sends_empty_message_list(
+        self, handler, mock_llm_client, mock_tool_registry
+    ):
+        """A structured `messages` list whose only entry has empty content (e.g. a bare
+        Slack @mention with no other text) must not collapse the conversation history down
+        to just the system message — providers like Anthropic reject a messages array with
+        no user/assistant turn at all ("at least one message is required")."""
+        with patch.object(handler, "_generate_with_tools", new_callable=AsyncMock) as mock_gen_tools:
+            response = MagicMock()
+            response.choices = [MagicMock()]
+            response.choices[0].message.tool_calls = None
+            response.choices[0].message.content = "ok"
+            mock_gen_tools.return_value = response
+
+            chunks = [
+                c
+                async for c in handler.generate_with_functions_stream(
+                    "System prompt", messages=[{"role": "user", "content": ""}]
+                )
+            ]
+
+            assert any(c["type"] == "text" for c in chunks)
+            conversation_history = mock_gen_tools.call_args[0][0]
+            non_system_turns = [m for m in conversation_history if m["role"] != "system"]
+            assert len(non_system_turns) >= 1
+            assert non_system_turns[0]["content"]  # must be truthy, not ""
+
     def test_extract_text_response(self, handler):
         # OpenAI style
         response = MagicMock()

--- a/api/tests/unit/services/slack/test_slack_message_handler.py
+++ b/api/tests/unit/services/slack/test_slack_message_handler.py
@@ -298,7 +298,7 @@ class TestBotSenderReplyGating:
 
         return handler
 
-    async def _run(self, wired_handler, mock_client, is_bot_sender, response_chunks):
+    async def _run(self, wired_handler, mock_client, is_bot_sender, response_chunks, text="<@U0BOTID> hello"):
         captured_kwargs = {}
 
         async def fake_stream(**kwargs):
@@ -320,7 +320,7 @@ class TestBotSenderReplyGating:
                 ),
                 channel_id="C123",
                 user_id="U-BOT",
-                text="<@U0BOTID> hello",
+                text=text,
                 message_ts="123.456",
                 thread_ts=None,
                 client=mock_client,
@@ -366,6 +366,18 @@ class TestBotSenderReplyGating:
         assert result == "Thanks, done."
         mock_client.chat_postMessage.assert_called_once()
         assert mock_client.chat_postMessage.call_args.kwargs["text"] == "Thanks, done."
+
+    @pytest.mark.asyncio
+    async def test_bare_mention_with_no_other_text_is_not_sent_as_empty_message(self, wired_handler, mock_client):
+        """A message that's just "@bot" with nothing else must never reach the agent as an
+        empty string — some tool-calling code paths silently drop an empty-content turn,
+        which can collapse the whole messages list to zero entries and get a 400 back from
+        the LLM provider ("at least one message is required")."""
+        _, captured_kwargs = await self._run(
+            wired_handler, mock_client, is_bot_sender=False, response_chunks=["Hi there!"], text="<@U0BOTID>"
+        )
+
+        assert captured_kwargs["message"].strip() != ""
 
 
 class TestUploadDiagrams:


### PR DESCRIPTION
## Summary
Production Sentry error: `BadRequestError 400 - messages: at least one message is required` from Anthropic.

Root cause, traced end-to-end:
1. A Slack message that's just a bare `@mention` with no other text resolves to `""` after `_remove_bot_mention` strips the mention.
2. `chat_stream_service._build_prompt()` unconditionally appends the current turn, producing a single `{"role": "user", "content": ""}` history entry.
3. `function_calling.py`'s `generate_with_functions_stream()` filters messages with `if role in ["user", "assistant"] and content:` — `""` is falsy, so that lone entry gets silently dropped, leaving only the system message.
4. `_convert_history_to_anthropic_format()` strips system messages (Anthropic takes them top-level), leaving a genuinely empty `messages` array — which Anthropic rejects outright.

Two fixes:
- `slack_message_handler.py`: substitute a fallback (`"Hi!"`) when the cleaned text is empty/whitespace, before it ever becomes `context_message`.
- `function_calling.py`: safety net — if every turn had empty content and got filtered out (leaving just the system message), append a placeholder user turn. This protects **any** trigger source, not just Slack.

Not specific to the recently-merged bot-tagging work (#183) — this has been reachable by any human sending a bare `@mention` with no text, since `_remove_bot_mention` first existed.

## Test plan
- [x] Added `test_bare_mention_with_no_other_text_is_not_sent_as_empty_message` (`test_slack_message_handler.py`) and `test_generate_with_functions_stream_never_sends_empty_message_list` (`test_function_calling.py`).
- [x] Ran full `tests/unit/services/agents/`, `tests/unit/services/slack/`, `tests/unit/controllers/agents/` via `docker-compose exec api pytest` — 1689 passed; the only 5 failures are pre-existing, unrelated `pypdf`-missing-in-container environment drift (confirmed via traceback on each).

🤖 Generated with [Claude Code](https://claude.com/claude-code)