### PR TITLE
fix: store OAuthApp.token_expires_at as naive datetime, not tz-aware

### DIFF
--- a/api/src/services/agents/credential_resolver.py
+++ b/api/src/services/agents/credential_resolver.py
@@ -512,8 +512,12 @@ class CredentialResolver:
                     if token_data.get("refresh_token"):
                         oauth_app.refresh_token = encrypt_value(token_data["refresh_token"])
                     expires_in = token_data.get("expires_in")
+                    # OAuthApp.token_expires_at is a plain (non-tz) DateTime column — unlike
+                    # UserOAuthToken's DateTime(timezone=True) — so it must be stored naive,
+                    # or asyncpg rejects the write ("can't subtract offset-naive and
+                    # offset-aware datetimes").
                     oauth_app.token_expires_at = (
-                        datetime.now(UTC) + timedelta(seconds=expires_in) if expires_in else None
+                        (datetime.now(UTC) + timedelta(seconds=expires_in)).replace(tzinfo=None) if expires_in else None
                     )
                     await self.db.commit()
                     logger.info(f"✅ Successfully refreshed GitLab token for app '{oauth_app.app_name}'")
@@ -1014,7 +1018,12 @@ class CredentialResolver:
                     if "expires_in" in token_data:
                         from datetime import timedelta
 
-                        oauth_app.token_expires_at = datetime.now(UTC) + timedelta(seconds=token_data["expires_in"])
+                        # OAuthApp.token_expires_at is a plain (non-tz) DateTime column —
+                        # must be stored naive or asyncpg rejects the write ("can't
+                        # subtract offset-naive and offset-aware datetimes").
+                        oauth_app.token_expires_at = (
+                            datetime.now(UTC) + timedelta(seconds=token_data["expires_in"])
+                        ).replace(tzinfo=None)
 
                     await self.db.commit()
 
@@ -1220,7 +1229,12 @@ class CredentialResolver:
                     if "expires_in" in token_data:
                         from datetime import timedelta
 
-                        oauth_app.token_expires_at = datetime.now(UTC) + timedelta(seconds=token_data["expires_in"])
+                        # OAuthApp.token_expires_at is a plain (non-tz) DateTime column —
+                        # must be stored naive or asyncpg rejects the write ("can't
+                        # subtract offset-naive and offset-aware datetimes").
+                        oauth_app.token_expires_at = (
+                            datetime.now(UTC) + timedelta(seconds=token_data["expires_in"])
+                        ).replace(tzinfo=None)
 
                     await self.db.commit()
 
@@ -1411,7 +1425,12 @@ class CredentialResolver:
                     if "expires_in" in token_data:
                         from datetime import timedelta
 
-                        oauth_app.token_expires_at = datetime.now(UTC) + timedelta(seconds=token_data["expires_in"])
+                        # OAuthApp.token_expires_at is a plain (non-tz) DateTime column —
+                        # must be stored naive or asyncpg rejects the write ("can't
+                        # subtract offset-naive and offset-aware datetimes").
+                        oauth_app.token_expires_at = (
+                            datetime.now(UTC) + timedelta(seconds=token_data["expires_in"])
+                        ).replace(tzinfo=None)
 
                     await self.db.commit()
 
@@ -1808,8 +1827,12 @@ class CredentialResolver:
                         if token_data.get("refresh_token"):
                             oauth_app.refresh_token = encrypt_value(token_data["refresh_token"])
                         expires_in = token_data.get("expires_in")
+                        # OAuthApp.token_expires_at is a plain (non-tz) DateTime column —
+                        # must be stored naive or asyncpg rejects the write.
                         oauth_app.token_expires_at = (
-                            datetime.now(UTC) + timedelta(seconds=expires_in) if expires_in else None
+                            (datetime.now(UTC) + timedelta(seconds=expires_in)).replace(tzinfo=None)
+                            if expires_in
+                            else None
                         )
                         await self.db.commit()
                         logger.info(f"✅ Successfully refreshed Jira token for app '{oauth_app.app_name}'")

--- a/api/tests/integration/test_oauth_app_token_expiry_integration.py
+++ b/api/tests/integration/test_oauth_app_token_expiry_integration.py
@@ -1,0 +1,45 @@
+"""Regression coverage for a production incident: OAuthApp.token_expires_at is a plain
+(non-timezone-aware) DateTime column, but the GitLab/Jira/Zoom/Google Calendar/Google
+Drive token-refresh code in credential_resolver.py was writing timezone-aware
+datetime.now(UTC) values into it. asyncpg rejects that at commit time with
+"can't subtract offset-naive and offset-aware datetimes" — a mocked unit test can't
+reproduce this since it never touches a real DB column, so this hits Postgres for real.
+"""
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from sqlalchemy.exc import DBAPIError
+
+from src.models.oauth_app import OAuthApp
+
+
+class TestOAuthAppTokenExpiresAtColumnType:
+    @pytest.mark.asyncio
+    async def test_naive_datetime_persists_successfully(self, async_db_session, tenant):
+        app = OAuthApp(
+            tenant_id=tenant.id,
+            provider="gitlab",
+            app_name="test-gitlab-app-naive",
+            auth_method="oauth",
+            is_active=True,
+        )
+        app.token_expires_at = (datetime.now(UTC) + timedelta(hours=2)).replace(tzinfo=None)
+        async_db_session.add(app)
+        await async_db_session.commit()  # must not raise
+
+    @pytest.mark.asyncio
+    async def test_timezone_aware_datetime_fails_to_persist(self, async_db_session, tenant):
+        """Documents the exact failure mode this regression test guards against."""
+        app = OAuthApp(
+            tenant_id=tenant.id,
+            provider="gitlab",
+            app_name="test-gitlab-app-aware",
+            auth_method="oauth",
+            is_active=True,
+        )
+        app.token_expires_at = datetime.now(UTC) + timedelta(hours=2)  # tz-aware — must fail
+        async_db_session.add(app)
+        with pytest.raises(DBAPIError, match="offset-naive and offset-aware"):
+            await async_db_session.commit()
+        await async_db_session.rollback()

--- a/api/tests/unit/services/agents/test_credential_resolver.py
+++ b/api/tests/unit/services/agents/test_credential_resolver.py
@@ -272,6 +272,12 @@ class TestGetGitlabToken:
         assert mock_oauth_app.access_token == "enc:new-access-token"
         assert mock_oauth_app.refresh_token == "enc:new-refresh-token"
         assert mock_oauth_app.token_expires_at is not None
+        # OAuthApp.token_expires_at is a plain (non-tz) DateTime column — a tz-aware
+        # value here makes asyncpg reject the write with a DataError at commit time
+        # ("can't subtract offset-naive and offset-aware datetimes"). A mocked
+        # oauth_app can't reproduce that failure itself, so this assertion is the
+        # regression guard for it.
+        assert mock_oauth_app.token_expires_at.tzinfo is None
         mock_db_session.commit.assert_awaited_once()
 
     @pytest.mark.asyncio
@@ -403,6 +409,9 @@ class TestGetJiraCredentials:
         assert credentials["cloud_id"] == "cloud-123"
         mock_jira_oauth.refresh_token.assert_awaited_once_with("old-decrypted-refresh-token")
         assert mock_oauth_app.access_token == "enc:new-jira-token"
+        # OAuthApp.token_expires_at is a plain (non-tz) DateTime column — regression
+        # guard, see the matching GitLab test for why this must be naive.
+        assert mock_oauth_app.token_expires_at.tzinfo is None
         mock_db_session.commit.assert_awaited_once()
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
**This is a live production regression from the just-merged GitLab/Jira OAuth refresh fix (#185).** Users started seeing `{"success": false, "error": "No GitLab access token available. Please configure GitLab OAuth or API token."}` and asked whether they needed to reauthenticate — they did not; this is a bug, confirmed via production logs:

```
ERROR [src.services.agents.credential_resolver] Failed to refresh GitLab token: (sqlalchemy.dialects.postgresql.asyncpg.Error)
<class 'asyncpg.exceptions.DataError'>: invalid input for query argument $3: ...
(can't subtract offset-naive and offset-aware datetimes)
  File "credential_resolver.py", line 518, in get_gitlab_token
```

**Root cause:** `OAuthApp.token_expires_at` is a plain `DateTime` column (no timezone), but the new refresh code wrote `datetime.now(UTC)` (timezone-*aware*) into it. asyncpg rejects that at commit time. The refresh against GitLab's API actually succeeded — the token just never got saved, so every subsequent call saw the same still-expired token and failed identically, looping until retries were exhausted.

(For contrast: `UserOAuthToken.token_expires_at` *is* `DateTime(timezone=True)`, so the aware-datetime writes there are correct — only the `OAuthApp`-level writes needed fixing.)

**Also fixed the identical pre-existing bug in Zoom/Google Calendar/Google Drive's refresh code** (same column type, same pattern) — same fix, before it caused the same incident there too.

## Test plan
- [x] Strengthened the existing GitLab/Jira refresh unit tests to assert `token_expires_at.tzinfo is None`.
- [x] Added `tests/integration/test_oauth_app_token_expiry_integration.py` — writes a real `OAuthApp` row through a real DB session. A mocked object can't reproduce a column-type mismatch, so this is the only way to actually catch this class of bug; it confirms both that the fix persists cleanly and that a tz-aware value reproduces the exact original `DataError`.
- [x] Ran `tests/unit/services/agents/` (credential_resolver + jira/gitlab/zoom tool tests) and the new integration test via `docker-compose exec api pytest` — all pass, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)