### PR TITLE
fix: stop double-encrypting personal OAuth tokens across all 16 providers

### DIFF
--- a/api/src/controllers/oauth/clickup.py
+++ b/api/src/controllers/oauth/clickup.py
@@ -158,7 +158,11 @@ async def clickup_callback(
 
             if existing_token:
                 # Update existing token
-                existing_token.access_token = encrypt_value(access_token)
+                # UserOAuthToken.access_token/.refresh_token are auto-encrypting
+                # properties — assigning an already-encrypted value here would
+                # double-encrypt it, producing a token that never decrypts back
+                # to something usable.
+                existing_token.access_token = access_token
                 existing_token.provider_user_id = str(user_info.get("id"))
                 existing_token.provider_email = user_email
                 existing_token.provider_username = username
@@ -168,7 +172,8 @@ async def clickup_callback(
                 user_token = UserOAuthToken(
                     account_id=uuid.UUID(account_id),
                     oauth_app_id=oauth_app_id,
-                    access_token=encrypt_value(access_token),
+                    # See comment above — this property encrypts on assignment.
+                    access_token=access_token,
                     provider_user_id=str(user_info.get("id")),
                     provider_email=user_email,
                     provider_username=username,

--- a/api/src/controllers/oauth/github.py
+++ b/api/src/controllers/oauth/github.py
@@ -166,7 +166,11 @@ async def github_callback(
 
             if existing_token:
                 # Update existing token
-                existing_token.access_token = encrypt_value(token)
+                # UserOAuthToken.access_token/.refresh_token are auto-encrypting
+                # properties — assigning an already-encrypted value here would
+                # double-encrypt it, producing a token that never decrypts back
+                # to something usable.
+                existing_token.access_token = token
                 existing_token.provider_user_id = str(user_info.get("id"))
                 existing_token.provider_email = user_info.get("email")
                 existing_token.provider_username = user_info.get("login")
@@ -177,7 +181,8 @@ async def github_callback(
                 user_token = UserOAuthToken(
                     account_id=uuid.UUID(account_id),
                     oauth_app_id=oauth_app_id,
-                    access_token=encrypt_value(token),
+                    # See comment above — this property encrypts on assignment.
+                    access_token=token,
                     provider_user_id=str(user_info.get("id")),
                     provider_email=user_info.get("email"),
                     provider_username=user_info.get("login"),

--- a/api/src/controllers/oauth/gitlab.py
+++ b/api/src/controllers/oauth/gitlab.py
@@ -185,9 +185,12 @@ async def gitlab_callback(
 
             if existing_token:
                 # Update existing token
-                existing_token.access_token = encrypt_value(token_data["access_token"])
+                # UserOAuthToken.access_token/.refresh_token are auto-encrypting
+                # properties — assigning an already-encrypted value here would
+                # double-encrypt it, producing a token GitLab always rejects.
+                existing_token.access_token = token_data["access_token"]
                 if token_data.get("refresh_token"):
-                    existing_token.refresh_token = encrypt_value(token_data["refresh_token"])
+                    existing_token.refresh_token = token_data["refresh_token"]
                 existing_token.token_expires_at = token_expires_at
                 existing_token.provider_user_id = str(user_info.get("id"))
                 existing_token.provider_email = user_info.get("email")
@@ -199,10 +202,9 @@ async def gitlab_callback(
                 user_token = UserOAuthToken(
                     account_id=uuid.UUID(account_id),
                     oauth_app_id=oauth_app_id,
-                    access_token=encrypt_value(token_data["access_token"]),
-                    refresh_token=encrypt_value(token_data["refresh_token"])
-                    if token_data.get("refresh_token")
-                    else None,
+                    # See comment above — these properties encrypt on assignment.
+                    access_token=token_data["access_token"],
+                    refresh_token=token_data.get("refresh_token"),
                     token_expires_at=token_expires_at,
                     provider_user_id=str(user_info.get("id")),
                     provider_email=user_info.get("email"),

--- a/api/src/controllers/oauth/google.py
+++ b/api/src/controllers/oauth/google.py
@@ -178,9 +178,13 @@ async def gmail_callback(
 
             if existing_token:
                 # Update existing token
-                existing_token.access_token = encrypt_value(json.dumps(credentials_json))
+                # UserOAuthToken.access_token/.refresh_token are auto-encrypting
+                # properties — assigning an already-encrypted value here would
+                # double-encrypt it, producing a token that never decrypts back
+                # to something usable.
+                existing_token.access_token = json.dumps(credentials_json)
                 if token_data.get("refresh_token"):
-                    existing_token.refresh_token = encrypt_value(token_data["refresh_token"])
+                    existing_token.refresh_token = token_data["refresh_token"]
                 existing_token.provider_user_id = user_info.get("id")
                 existing_token.provider_email = user_email
                 existing_token.provider_display_name = user_info.get("name")
@@ -189,10 +193,9 @@ async def gmail_callback(
                 user_token = UserOAuthToken(
                     account_id=uuid.UUID(account_id),
                     oauth_app_id=oauth_app_id,
-                    access_token=encrypt_value(json.dumps(credentials_json)),
-                    refresh_token=encrypt_value(token_data["refresh_token"])
-                    if token_data.get("refresh_token")
-                    else None,
+                    # See comment above — these properties encrypt on assignment.
+                    access_token=json.dumps(credentials_json),
+                    refresh_token=token_data.get("refresh_token"),
                     provider_user_id=user_info.get("id"),
                     provider_email=user_email,
                     provider_display_name=user_info.get("name"),
@@ -380,9 +383,13 @@ async def google_calendar_callback(
 
             if existing_token:
                 # Update existing token
-                existing_token.access_token = encrypt_value(token_data["access_token"])
+                # UserOAuthToken.access_token/.refresh_token are auto-encrypting
+                # properties — assigning an already-encrypted value here would
+                # double-encrypt it, producing a token that never decrypts back
+                # to something usable.
+                existing_token.access_token = token_data["access_token"]
                 if token_data.get("refresh_token"):
-                    existing_token.refresh_token = encrypt_value(token_data["refresh_token"])
+                    existing_token.refresh_token = token_data["refresh_token"]
                 existing_token.token_expires_at = token_expires_at
                 existing_token.provider_user_id = user_info.get("id")
                 existing_token.provider_email = user_email
@@ -392,10 +399,9 @@ async def google_calendar_callback(
                 user_token = UserOAuthToken(
                     account_id=uuid.UUID(account_id),
                     oauth_app_id=oauth_app_id,
-                    access_token=encrypt_value(token_data["access_token"]),
-                    refresh_token=encrypt_value(token_data["refresh_token"])
-                    if token_data.get("refresh_token")
-                    else None,
+                    # See comment above — these properties encrypt on assignment.
+                    access_token=token_data["access_token"],
+                    refresh_token=token_data.get("refresh_token"),
                     token_expires_at=token_expires_at,
                     provider_user_id=user_info.get("id"),
                     provider_email=user_email,
@@ -590,9 +596,13 @@ async def google_drive_callback(
 
             if existing_token:
                 # Update existing token
-                existing_token.access_token = encrypt_value(token_data["access_token"])
+                # UserOAuthToken.access_token/.refresh_token are auto-encrypting
+                # properties — assigning an already-encrypted value here would
+                # double-encrypt it, producing a token that never decrypts back
+                # to something usable.
+                existing_token.access_token = token_data["access_token"]
                 if token_data.get("refresh_token"):
-                    existing_token.refresh_token = encrypt_value(token_data["refresh_token"])
+                    existing_token.refresh_token = token_data["refresh_token"]
                 existing_token.token_expires_at = token_expires_at
                 existing_token.provider_user_id = user_info.get("id")
                 existing_token.provider_email = user_email
@@ -602,10 +612,9 @@ async def google_drive_callback(
                 user_token = UserOAuthToken(
                     account_id=uuid.UUID(account_id),
                     oauth_app_id=oauth_app_id,
-                    access_token=encrypt_value(token_data["access_token"]),
-                    refresh_token=encrypt_value(token_data["refresh_token"])
-                    if token_data.get("refresh_token")
-                    else None,
+                    # See comment above — these properties encrypt on assignment.
+                    access_token=token_data["access_token"],
+                    refresh_token=token_data.get("refresh_token"),
                     token_expires_at=token_expires_at,
                     provider_user_id=user_info.get("id"),
                     provider_email=user_email,

--- a/api/src/controllers/oauth/hubspot.py
+++ b/api/src/controllers/oauth/hubspot.py
@@ -147,9 +147,13 @@ async def hubspot_callback(
             )
             existing = result.scalar_one_or_none()
             if existing:
-                existing.access_token = encrypt_value(access_token)
+                # UserOAuthToken.access_token/.refresh_token are auto-encrypting
+                # properties — assigning an already-encrypted value here would
+                # double-encrypt it, producing a token that never decrypts back
+                # to something usable.
+                existing.access_token = access_token
                 if refresh_token:
-                    existing.refresh_token = encrypt_value(refresh_token)
+                    existing.refresh_token = refresh_token
                 existing.token_expires_at = token_expires_at
                 existing.provider_user_id = user_info.get("id")
                 existing.provider_email = user_email
@@ -159,8 +163,9 @@ async def hubspot_callback(
                     UserOAuthToken(
                         account_id=uuid.UUID(account_id),
                         oauth_app_id=oauth_app_id,
-                        access_token=encrypt_value(access_token),
-                        refresh_token=encrypt_value(refresh_token) if refresh_token else None,
+                        # See comment above — these properties encrypt on assignment.
+                        access_token=access_token,
+                        refresh_token=refresh_token,
                         token_expires_at=token_expires_at,
                         provider_user_id=user_info.get("id"),
                         provider_email=user_email,

--- a/api/src/controllers/oauth/intercom.py
+++ b/api/src/controllers/oauth/intercom.py
@@ -143,7 +143,11 @@ async def intercom_callback(
             )
             existing = result.scalar_one_or_none()
             if existing:
-                existing.access_token = encrypt_value(access_token)
+                # UserOAuthToken.access_token is an auto-encrypting property —
+                # assigning an already-encrypted value here would double-encrypt
+                # it, producing a token that never decrypts back to something
+                # usable.
+                existing.access_token = access_token
                 existing.token_expires_at = None
                 existing.provider_user_id = user_info.get("id")
                 existing.provider_email = user_email
@@ -153,7 +157,8 @@ async def intercom_callback(
                     UserOAuthToken(
                         account_id=uuid.UUID(account_id),
                         oauth_app_id=oauth_app_id,
-                        access_token=encrypt_value(access_token),
+                        # See comment above — this property encrypts on assignment.
+                        access_token=access_token,
                         token_expires_at=None,
                         provider_user_id=user_info.get("id"),
                         provider_email=user_email,

--- a/api/src/controllers/oauth/jira.py
+++ b/api/src/controllers/oauth/jira.py
@@ -176,9 +176,13 @@ async def jira_callback(
 
             if existing_token:
                 # Update existing token
-                existing_token.access_token = encrypt_value(access_token)
+                # UserOAuthToken.access_token/.refresh_token are auto-encrypting
+                # properties — assigning an already-encrypted value here would
+                # double-encrypt it, producing a token that never decrypts back
+                # to something usable.
+                existing_token.access_token = access_token
                 if refresh_token:
-                    existing_token.refresh_token = encrypt_value(refresh_token)
+                    existing_token.refresh_token = refresh_token
                 existing_token.token_expires_at = token_expires_at
                 existing_token.provider_user_id = user_info.get("account_id")
                 existing_token.provider_email = user_email
@@ -188,8 +192,9 @@ async def jira_callback(
                 user_token = UserOAuthToken(
                     account_id=uuid.UUID(account_id),
                     oauth_app_id=oauth_app_id,
-                    access_token=encrypt_value(access_token),
-                    refresh_token=encrypt_value(refresh_token) if refresh_token else None,
+                    # See comment above — these properties encrypt on assignment.
+                    access_token=access_token,
+                    refresh_token=refresh_token,
                     token_expires_at=token_expires_at,
                     provider_user_id=user_info.get("account_id"),
                     provider_email=user_email,

--- a/api/src/controllers/oauth/linkedin.py
+++ b/api/src/controllers/oauth/linkedin.py
@@ -183,17 +183,22 @@ async def linkedin_callback(
             existing_token = result.scalar_one_or_none()
 
             if existing_token:
-                existing_token.access_token = encrypt_value(access_token)
+                # UserOAuthToken.access_token/.refresh_token are auto-encrypting
+                # properties — assigning an already-encrypted value here would
+                # double-encrypt it, producing a token that never decrypts back
+                # to something usable.
+                existing_token.access_token = access_token
                 if refresh_token:
-                    existing_token.refresh_token = encrypt_value(refresh_token)
+                    existing_token.refresh_token = refresh_token
                 existing_token.provider_user_id = user_id
                 existing_token.provider_display_name = user_name
             else:
                 user_token = UserOAuthToken(
                     account_id=uuid.UUID(account_id),
                     oauth_app_id=oauth_app_id,
-                    access_token=encrypt_value(access_token),
-                    refresh_token=encrypt_value(refresh_token) if refresh_token else None,
+                    # See comment above — these properties encrypt on assignment.
+                    access_token=access_token,
+                    refresh_token=refresh_token,
                     provider_user_id=user_id,
                     provider_display_name=user_name,
                 )

--- a/api/src/controllers/oauth/micromobility.py
+++ b/api/src/controllers/oauth/micromobility.py
@@ -173,9 +173,13 @@ async def micromobility_callback(
             existing_token = result.scalar_one_or_none()
 
             if existing_token:
-                existing_token.access_token = encrypt_value(access_token)
+                # UserOAuthToken.access_token/.refresh_token are auto-encrypting
+                # properties — assigning an already-encrypted value here would
+                # double-encrypt it, producing a token that never decrypts back
+                # to something usable.
+                existing_token.access_token = access_token
                 if refresh_token:
-                    existing_token.refresh_token = encrypt_value(refresh_token)
+                    existing_token.refresh_token = refresh_token
                 existing_token.token_expires_at = token_expires_at
                 existing_token.provider_email = user_email
             else:
@@ -183,8 +187,9 @@ async def micromobility_callback(
                     UserOAuthToken(
                         account_id=uuid.UUID(account_id),
                         oauth_app_id=oauth_app_id,
-                        access_token=encrypt_value(access_token),
-                        refresh_token=encrypt_value(refresh_token) if refresh_token else None,
+                        # See comment above — these properties encrypt on assignment.
+                        access_token=access_token,
+                        refresh_token=refresh_token,
                         token_expires_at=token_expires_at,
                         provider_email=user_email,
                     )

--- a/api/src/controllers/oauth/salesforce.py
+++ b/api/src/controllers/oauth/salesforce.py
@@ -164,9 +164,13 @@ async def salesforce_callback(
             )
             existing = result.scalar_one_or_none()
             if existing:
-                existing.access_token = encrypt_value(access_token)
+                # UserOAuthToken.access_token/.refresh_token are auto-encrypting
+                # properties — assigning an already-encrypted value here would
+                # double-encrypt it, producing a token that never decrypts back
+                # to something usable.
+                existing.access_token = access_token
                 if refresh_token:
-                    existing.refresh_token = encrypt_value(refresh_token)
+                    existing.refresh_token = refresh_token
                 existing.token_expires_at = token_expires_at
                 existing.provider_user_id = user_info.get("id")
                 existing.provider_email = user_email
@@ -176,8 +180,9 @@ async def salesforce_callback(
                     UserOAuthToken(
                         account_id=uuid.UUID(account_id),
                         oauth_app_id=oauth_app_id,
-                        access_token=encrypt_value(access_token),
-                        refresh_token=encrypt_value(refresh_token) if refresh_token else None,
+                        # See comment above — these properties encrypt on assignment.
+                        access_token=access_token,
+                        refresh_token=refresh_token,
                         token_expires_at=token_expires_at,
                         provider_user_id=user_info.get("id"),
                         provider_email=user_email,

--- a/api/src/controllers/oauth/slack.py
+++ b/api/src/controllers/oauth/slack.py
@@ -159,7 +159,11 @@ async def slack_callback(
 
             if existing_token:
                 # Update existing token
-                existing_token.access_token = encrypt_value(token_data["access_token"])
+                # UserOAuthToken.access_token/.refresh_token are auto-encrypting
+                # properties — assigning an already-encrypted value here would
+                # double-encrypt it, producing a token that never decrypts back
+                # to something usable.
+                existing_token.access_token = token_data["access_token"]
                 existing_token.provider_user_id = authed_user.get("id")
                 existing_token.provider_display_name = team_name
                 existing_token.scopes = token_data.get("scope", "")
@@ -168,7 +172,8 @@ async def slack_callback(
                 user_token = UserOAuthToken(
                     account_id=uuid.UUID(account_id),
                     oauth_app_id=oauth_app_id,
-                    access_token=encrypt_value(token_data["access_token"]),
+                    # See comment above — this property encrypts on assignment.
+                    access_token=token_data["access_token"],
                     provider_user_id=authed_user.get("id"),
                     provider_display_name=team_name,
                     scopes=token_data.get("scope", ""),

--- a/api/src/controllers/oauth/tokens.py
+++ b/api/src/controllers/oauth/tokens.py
@@ -17,7 +17,6 @@ from ...middleware.auth_middleware import get_current_account, get_current_tenan
 from ...models.oauth_app import OAuthApp
 from ...models.tenant import Account
 from ...models.user_oauth_token import UserOAuthToken
-from ...services.agents.security import encrypt_value
 from .base import (
     SaveUserApiTokenRequest,
     _get_oauth_app_secure,
@@ -154,7 +153,11 @@ async def save_user_api_token(
 
         if existing_token:
             # Update existing token
-            existing_token.access_token = encrypt_value(data.api_token)
+            # UserOAuthToken.access_token is an auto-encrypting property —
+            # assigning an already-encrypted value here would double-encrypt
+            # it, producing a token that never decrypts back to something
+            # usable.
+            existing_token.access_token = data.api_token
             existing_token.refresh_token = None  # API tokens don't have refresh tokens
             await db.commit()
             logger.info(f"User {current_account.id} updated API token for {oauth_app.provider}")
@@ -163,7 +166,8 @@ async def save_user_api_token(
             new_token = UserOAuthToken(
                 account_id=current_account.id,
                 oauth_app_id=data.oauth_app_id,
-                access_token=encrypt_value(data.api_token),
+                # See comment above — this property encrypts on assignment.
+                access_token=data.api_token,
                 refresh_token=None,
                 provider_user_id=None,
                 provider_email=current_account.email,  # Use account email as identifier

--- a/api/src/controllers/oauth/twitter.py
+++ b/api/src/controllers/oauth/twitter.py
@@ -175,17 +175,22 @@ async def twitter_callback(
             existing_token = result.scalar_one_or_none()
 
             if existing_token:
-                existing_token.access_token = encrypt_value(access_token)
+                # UserOAuthToken.access_token/.refresh_token are auto-encrypting
+                # properties — assigning an already-encrypted value here would
+                # double-encrypt it, producing a token that never decrypts back
+                # to something usable.
+                existing_token.access_token = access_token
                 if refresh_token:
-                    existing_token.refresh_token = encrypt_value(refresh_token)
+                    existing_token.refresh_token = refresh_token
                 existing_token.provider_user_id = user_info.get("id")
                 existing_token.provider_display_name = f"@{username}"
             else:
                 user_token = UserOAuthToken(
                     account_id=uuid.UUID(account_id),
                     oauth_app_id=oauth_app_id,
-                    access_token=encrypt_value(access_token),
-                    refresh_token=encrypt_value(refresh_token) if refresh_token else None,
+                    # See comment above — these properties encrypt on assignment.
+                    access_token=access_token,
+                    refresh_token=refresh_token,
                     provider_user_id=user_info.get("id"),
                     provider_display_name=f"@{username}",
                 )

--- a/api/src/controllers/oauth/zendesk.py
+++ b/api/src/controllers/oauth/zendesk.py
@@ -154,7 +154,11 @@ async def zendesk_callback(
             )
             existing = result.scalar_one_or_none()
             if existing:
-                existing.access_token = encrypt_value(access_token)
+                # UserOAuthToken.access_token is an auto-encrypting property —
+                # assigning an already-encrypted value here would double-encrypt
+                # it, producing a token that never decrypts back to something
+                # usable.
+                existing.access_token = access_token
                 existing.token_expires_at = None
                 existing.provider_user_id = user_info.get("id")
                 existing.provider_email = user_email
@@ -164,7 +168,8 @@ async def zendesk_callback(
                     UserOAuthToken(
                         account_id=uuid.UUID(account_id),
                         oauth_app_id=oauth_app_id,
-                        access_token=encrypt_value(access_token),
+                        # See comment above — this property encrypts on assignment.
+                        access_token=access_token,
                         token_expires_at=None,
                         provider_user_id=user_info.get("id"),
                         provider_email=user_email,

--- a/api/src/controllers/oauth/zoho.py
+++ b/api/src/controllers/oauth/zoho.py
@@ -156,9 +156,13 @@ async def zoho_callback(
             )
             existing = result.scalar_one_or_none()
             if existing:
-                existing.access_token = encrypt_value(access_token)
+                # UserOAuthToken.access_token/.refresh_token are auto-encrypting
+                # properties — assigning an already-encrypted value here would
+                # double-encrypt it, producing a token that never decrypts back
+                # to something usable.
+                existing.access_token = access_token
                 if refresh_token:
-                    existing.refresh_token = encrypt_value(refresh_token)
+                    existing.refresh_token = refresh_token
                 existing.token_expires_at = token_expires_at
                 existing.provider_user_id = user_info.get("id")
                 existing.provider_email = user_email
@@ -168,8 +172,9 @@ async def zoho_callback(
                     UserOAuthToken(
                         account_id=uuid.UUID(account_id),
                         oauth_app_id=oauth_app_id,
-                        access_token=encrypt_value(access_token),
-                        refresh_token=encrypt_value(refresh_token) if refresh_token else None,
+                        # See comment above — these properties encrypt on assignment.
+                        access_token=access_token,
+                        refresh_token=refresh_token,
                         token_expires_at=token_expires_at,
                         provider_user_id=user_info.get("id"),
                         provider_email=user_email,

--- a/api/src/controllers/oauth/zoom.py
+++ b/api/src/controllers/oauth/zoom.py
@@ -172,9 +172,13 @@ async def zoom_callback(
 
             if existing_token:
                 # Update existing token
-                existing_token.access_token = encrypt_value(token_data["access_token"])
+                # UserOAuthToken.access_token/.refresh_token are auto-encrypting
+                # properties — assigning an already-encrypted value here would
+                # double-encrypt it, producing a token that never decrypts back
+                # to something usable.
+                existing_token.access_token = token_data["access_token"]
                 if token_data.get("refresh_token"):
-                    existing_token.refresh_token = encrypt_value(token_data["refresh_token"])
+                    existing_token.refresh_token = token_data["refresh_token"]
                 existing_token.token_expires_at = token_expires_at
                 existing_token.provider_user_id = user_info.get("id")
                 existing_token.provider_email = user_email
@@ -187,10 +191,9 @@ async def zoom_callback(
                 user_token = UserOAuthToken(
                     account_id=uuid.UUID(account_id),
                     oauth_app_id=oauth_app_id,
-                    access_token=encrypt_value(token_data["access_token"]),
-                    refresh_token=encrypt_value(token_data["refresh_token"])
-                    if token_data.get("refresh_token")
-                    else None,
+                    # See comment above — these properties encrypt on assignment.
+                    access_token=token_data["access_token"],
+                    refresh_token=token_data.get("refresh_token"),
                     token_expires_at=token_expires_at,
                     provider_user_id=user_info.get("id"),
                     provider_email=user_email,

--- a/api/src/services/agents/credential_resolver.py
+++ b/api/src/services/agents/credential_resolver.py
@@ -103,6 +103,31 @@ class CredentialResolver:
 
         return None
 
+    @staticmethod
+    def _resolve_user_token_value(value: str | None) -> str | None:
+        """Read a UserOAuthToken.access_token/.refresh_token property value.
+
+        UserOAuthToken.access_token/.refresh_token are auto-encrypting properties —
+        reading them already returns plaintext. Every OAuth provider callback used to
+        call encrypt_value() before assigning to them, which double-encrypted the
+        value (the property setter encrypted it a second time); some resolver code
+        here also called decrypt_value() a second time on read, which happened to
+        cancel that out for those legacy rows. Both bugs are now fixed at the source
+        (the callbacks no longer double-encrypt), but existing DB rows saved before
+        that fix are still double-encrypted. This stays resilient to both: try
+        decrypting once more — if the value was legacy double-encrypted, this
+        unwraps the leftover layer; if it's already plaintext (new, correctly-saved
+        rows), decryption fails and the value is used as-is.
+        """
+        if value is None:
+            return None
+        from src.services.agents.security import decrypt_value
+
+        try:
+            return decrypt_value(value)
+        except Exception:
+            return value
+
     async def _get_user_token(self, oauth_app_id: int) -> str | None:
         """
         Get user's personal token (simple lookup without refresh).
@@ -116,11 +141,9 @@ class CredentialResolver:
         Returns:
             Decrypted access token string or None if not found
         """
-        from src.services.agents.security import decrypt_value
-
         user_token_record = await self._get_user_token_record(oauth_app_id)
         if user_token_record and user_token_record.access_token:
-            return decrypt_value(user_token_record.access_token)
+            return self._resolve_user_token_value(user_token_record.access_token)
         return None
 
     async def get_github_client(self, tool_name: str, owner: str | None = None, repo: str | None = None) -> Any | None:
@@ -933,7 +956,7 @@ class CredentialResolver:
                         # Get credentials from OAuth app (client_id is plain text, client_secret is encrypted)
                         client_id = oauth_app.client_id
                         client_secret = decrypt_value(oauth_app.client_secret) if oauth_app.client_secret else None
-                        refresh_token = decrypt_value(user_token_record.refresh_token)
+                        refresh_token = self._resolve_user_token_value(user_token_record.refresh_token)
 
                         if client_id and client_secret:
                             zoom_oauth = ZoomOAuth(
@@ -943,9 +966,12 @@ class CredentialResolver:
                             token_data = await zoom_oauth.refresh_access_token(refresh_token)
 
                             # Update user token record
-                            user_token_record.access_token = encrypt_value(token_data["access_token"])
+                            # UserOAuthToken.access_token/.refresh_token are auto-encrypting
+                            # properties — assigning an already-encrypted value here would
+                            # double-encrypt it.
+                            user_token_record.access_token = token_data["access_token"]
                             if "refresh_token" in token_data:
-                                user_token_record.refresh_token = encrypt_value(token_data["refresh_token"])
+                                user_token_record.refresh_token = token_data["refresh_token"]
                             if "expires_in" in token_data:
                                 from datetime import timedelta
 
@@ -963,7 +989,7 @@ class CredentialResolver:
 
                 elif not user_token_expired:
                     # Token is still valid
-                    token = decrypt_value(user_token_record.access_token)
+                    token = self._resolve_user_token_value(user_token_record.access_token)
                     logger.info(
                         f"✅ Resolved Zoom token for tool '{tool_name}' "
                         f"using user's personal token (OAuth app: '{oauth_app.app_name}')"
@@ -1146,7 +1172,7 @@ class CredentialResolver:
                         # Get credentials from OAuth app (client_id is plain text, client_secret is encrypted)
                         client_id = oauth_app.client_id
                         client_secret = decrypt_value(oauth_app.client_secret) if oauth_app.client_secret else None
-                        refresh_token = decrypt_value(user_token_record.refresh_token)
+                        refresh_token = self._resolve_user_token_value(user_token_record.refresh_token)
 
                         if client_id and client_secret:
                             google_oauth = GoogleCalendarOAuth(
@@ -1156,9 +1182,12 @@ class CredentialResolver:
                             token_data = await google_oauth.refresh_token(refresh_token)
 
                             # Update user token record
-                            user_token_record.access_token = encrypt_value(token_data["access_token"])
+                            # UserOAuthToken.access_token/.refresh_token are auto-encrypting
+                            # properties — assigning an already-encrypted value here would
+                            # double-encrypt it.
+                            user_token_record.access_token = token_data["access_token"]
                             if "refresh_token" in token_data:
-                                user_token_record.refresh_token = encrypt_value(token_data["refresh_token"])
+                                user_token_record.refresh_token = token_data["refresh_token"]
                             if "expires_in" in token_data:
                                 from datetime import timedelta
 
@@ -1176,7 +1205,7 @@ class CredentialResolver:
 
                 elif not user_token_expired:
                     # Token is still valid
-                    token = decrypt_value(user_token_record.access_token)
+                    token = self._resolve_user_token_value(user_token_record.access_token)
                     logger.info(
                         f"✅ Resolved Google Calendar token for tool '{tool_name}' "
                         f"using user's personal token (OAuth app: '{oauth_app.app_name}')"
@@ -1342,7 +1371,7 @@ class CredentialResolver:
                         # Get credentials from OAuth app (client_id is plain text, client_secret is encrypted)
                         client_id = oauth_app.client_id
                         client_secret = decrypt_value(oauth_app.client_secret) if oauth_app.client_secret else None
-                        refresh_token = decrypt_value(user_token_record.refresh_token)
+                        refresh_token = self._resolve_user_token_value(user_token_record.refresh_token)
 
                         if client_id and client_secret:
                             google_oauth = GoogleDriveOAuth(
@@ -1352,9 +1381,12 @@ class CredentialResolver:
                             token_data = await google_oauth.refresh_token(refresh_token)
 
                             # Update user token record
-                            user_token_record.access_token = encrypt_value(token_data["access_token"])
+                            # UserOAuthToken.access_token/.refresh_token are auto-encrypting
+                            # properties — assigning an already-encrypted value here would
+                            # double-encrypt it.
+                            user_token_record.access_token = token_data["access_token"]
                             if "refresh_token" in token_data:
-                                user_token_record.refresh_token = encrypt_value(token_data["refresh_token"])
+                                user_token_record.refresh_token = token_data["refresh_token"]
                             if "expires_in" in token_data:
                                 from datetime import timedelta
 
@@ -1372,7 +1404,7 @@ class CredentialResolver:
 
                 elif not user_token_expired:
                     # Token is still valid
-                    token = decrypt_value(user_token_record.access_token)
+                    token = self._resolve_user_token_value(user_token_record.access_token)
                     logger.info(
                         f"✅ Resolved Google Drive token for tool '{tool_name}' "
                         f"using user's personal token (OAuth app: '{oauth_app.app_name}')"
@@ -2536,7 +2568,7 @@ class CredentialResolver:
                         logger.info("🔄 Refreshing expired user Twitter token...")
                         client_id = oauth_app.client_id
                         client_secret = decrypt_value(oauth_app.client_secret) if oauth_app.client_secret else None
-                        refresh_token = decrypt_value(user_token_record.refresh_token)
+                        refresh_token = self._resolve_user_token_value(user_token_record.refresh_token)
 
                         if client_id and client_secret:
                             twitter_oauth = TwitterOAuth(
@@ -2544,9 +2576,12 @@ class CredentialResolver:
                             )
                             token_data = await twitter_oauth.refresh_access_token(refresh_token)
 
-                            user_token_record.access_token = encrypt_value(token_data["access_token"])
+                            # UserOAuthToken.access_token/.refresh_token are auto-encrypting
+                            # properties — assigning an already-encrypted value here would
+                            # double-encrypt it.
+                            user_token_record.access_token = token_data["access_token"]
                             if "refresh_token" in token_data:
-                                user_token_record.refresh_token = encrypt_value(token_data["refresh_token"])
+                                user_token_record.refresh_token = token_data["refresh_token"]
                             if "expires_in" in token_data:
                                 from datetime import timedelta
 
@@ -2561,7 +2596,7 @@ class CredentialResolver:
                         logger.error(f"Failed to refresh user Twitter token: {refresh_error}", exc_info=True)
 
                 elif not user_token_expired:
-                    token = decrypt_value(user_token_record.access_token)
+                    token = self._resolve_user_token_value(user_token_record.access_token)
                     logger.info(
                         f"✅ Resolved Twitter token for tool '{tool_name}' "
                         f"using user's personal token (OAuth app: '{oauth_app.app_name}')"
@@ -2646,7 +2681,7 @@ class CredentialResolver:
                         logger.info("🔄 Refreshing expired user LinkedIn token...")
                         client_id = oauth_app.client_id
                         client_secret = decrypt_value(oauth_app.client_secret) if oauth_app.client_secret else None
-                        refresh_token = decrypt_value(user_token_record.refresh_token)
+                        refresh_token = self._resolve_user_token_value(user_token_record.refresh_token)
 
                         if client_id and client_secret:
                             linkedin_oauth = LinkedInOAuth(
@@ -2654,9 +2689,12 @@ class CredentialResolver:
                             )
                             token_data = await linkedin_oauth.refresh_access_token(refresh_token)
 
-                            user_token_record.access_token = encrypt_value(token_data["access_token"])
+                            # UserOAuthToken.access_token/.refresh_token are auto-encrypting
+                            # properties — assigning an already-encrypted value here would
+                            # double-encrypt it.
+                            user_token_record.access_token = token_data["access_token"]
                             if "refresh_token" in token_data:
-                                user_token_record.refresh_token = encrypt_value(token_data["refresh_token"])
+                                user_token_record.refresh_token = token_data["refresh_token"]
                             if "expires_in" in token_data:
                                 from datetime import timedelta
 
@@ -2671,7 +2709,7 @@ class CredentialResolver:
                         logger.error(f"Failed to refresh user LinkedIn token: {refresh_error}", exc_info=True)
 
                 elif not user_token_expired:
-                    token = decrypt_value(user_token_record.access_token)
+                    token = self._resolve_user_token_value(user_token_record.access_token)
                     logger.info(
                         f"✅ Resolved LinkedIn token for tool '{tool_name}' "
                         f"using user's personal token (OAuth app: '{oauth_app.app_name}')"

--- a/api/tests/unit/controllers/oauth/test_user_oauth_token_no_double_encryption.py
+++ b/api/tests/unit/controllers/oauth/test_user_oauth_token_no_double_encryption.py
@@ -1,0 +1,103 @@
+"""Regression guard for a platform-wide bug found across every OAuth provider callback
+in src/controllers/oauth/ AND in src/services/agents/credential_resolver.py:
+UserOAuthToken.access_token/.refresh_token are auto-encrypting properties (see
+src/models/user_oauth_token.py), but:
+
+1. Every single provider callback was calling encrypt_value() before assigning to them —
+   double-encrypting the token at save time, so it never decrypted back to something
+   GitLab/Jira/Zoom/etc. would accept.
+2. Several credential_resolver.py read/refresh paths were calling decrypt_value() a
+   second time on top of the property's own decryption — which happened to cancel bug
+   #1 out by accident for existing rows, and would independently break correctly-saved
+   (single-encrypted) rows going forward.
+
+Every personal ("user-level") OAuth connection across the whole platform was silently
+broken by #1; the fix for #1 alone would have broken every one of those *existing* rows
+via #2, since #2 was accidentally compensating for #1. Both are now fixed: writes assign
+plaintext directly (the property encrypts), and reads go through
+CredentialResolver._resolve_user_token_value(), which transparently decrypts once more
+only if the value still looks encrypted — self-healing legacy double-encrypted rows
+without a data migration, while leaving correctly-saved rows untouched.
+
+These tests statically scan the source for both anti-patterns. A DB/mock-based test can't
+catch this class of bug — double-encrypting still "looks like" a valid Fernet token to a
+mock, it only fails against a real UserOAuthToken property or a real provider API call —
+so this is deliberately a source-level guard instead.
+"""
+
+import re
+from pathlib import Path
+
+OAUTH_CONTROLLERS_DIR = Path(__file__).parents[4] / "src" / "controllers" / "oauth"
+CREDENTIAL_RESOLVER_FILE = Path(__file__).parents[4] / "src" / "services" / "agents" / "credential_resolver.py"
+
+# Matches `<name>.access_token = encrypt_value(...)` or `<name>.refresh_token = encrypt_value(...)`
+# for any receiver name other than oauth_app (OAuthApp's plain columns).
+_ASSIGNMENT_PATTERN = re.compile(r"^\s*(?!oauth_app\.)(\w+)\.(access_token|refresh_token)\s*=\s*encrypt_value\(")
+
+# Matches `access_token=encrypt_value(...)` / `refresh_token=encrypt_value(...)` as a
+# constructor kwarg (used when building a new UserOAuthToken(...)).
+_KWARG_PATTERN = re.compile(r"^\s*(access_token|refresh_token)\s*=\s*encrypt_value\(")
+
+
+def _iter_oauth_controller_files():
+    assert OAUTH_CONTROLLERS_DIR.is_dir(), f"expected oauth controllers dir at {OAUTH_CONTROLLERS_DIR}"
+    return sorted(OAUTH_CONTROLLERS_DIR.glob("*.py"))
+
+
+def test_no_oauth_controller_double_encrypts_user_oauth_token():
+    violations = []
+    for path in _iter_oauth_controller_files():
+        for lineno, line in enumerate(path.read_text().splitlines(), start=1):
+            if _ASSIGNMENT_PATTERN.match(line) or _KWARG_PATTERN.match(line):
+                violations.append(f"{path.name}:{lineno}: {line.strip()}")
+
+    assert not violations, (
+        "Found encrypt_value() applied to a UserOAuthToken field — this double-encrypts "
+        "the token (the model's access_token/refresh_token are auto-encrypting properties) "
+        "and produces a token no provider will ever accept:\n" + "\n".join(violations)
+    )
+
+
+def test_oauth_controllers_still_encrypt_app_level_tokens():
+    """Sanity check that the guard above isn't just matching nothing — OAuthApp's plain
+    Text columns must still go through encrypt_value() explicitly."""
+    found_any = False
+    for path in _iter_oauth_controller_files():
+        text = path.read_text()
+        if re.search(r"oauth_app\.access_token\s*=\s*encrypt_value\(", text):
+            found_any = True
+            break
+
+    assert found_any, "expected at least one oauth controller to still encrypt oauth_app.access_token"
+
+
+def test_credential_resolver_does_not_double_encrypt_user_oauth_token():
+    assert CREDENTIAL_RESOLVER_FILE.is_file(), f"expected credential_resolver.py at {CREDENTIAL_RESOLVER_FILE}"
+    violations = []
+    for lineno, line in enumerate(CREDENTIAL_RESOLVER_FILE.read_text().splitlines(), start=1):
+        if re.match(r"^\s*user_token_record\.(access_token|refresh_token)\s*=\s*encrypt_value\(", line):
+            violations.append(f"{lineno}: {line.strip()}")
+
+    assert not violations, (
+        "Found encrypt_value() applied to user_token_record.access_token/.refresh_token in "
+        "credential_resolver.py — this double-encrypts the token (the property already "
+        "encrypts on assignment). Assign the plaintext value directly instead:\n" + "\n".join(violations)
+    )
+
+
+def test_credential_resolver_reads_user_oauth_token_through_resolver_helper():
+    """Reading user_token_record.access_token/.refresh_token must go through
+    CredentialResolver._resolve_user_token_value(), not a raw decrypt_value() call —
+    that helper is what makes both legacy double-encrypted rows and correctly-saved
+    single-encrypted rows resolve to the right plaintext."""
+    assert CREDENTIAL_RESOLVER_FILE.is_file(), f"expected credential_resolver.py at {CREDENTIAL_RESOLVER_FILE}"
+    violations = []
+    for lineno, line in enumerate(CREDENTIAL_RESOLVER_FILE.read_text().splitlines(), start=1):
+        if re.search(r"decrypt_value\(user_token_record\.(access_token|refresh_token)\)", line):
+            violations.append(f"{lineno}: {line.strip()}")
+
+    assert not violations, (
+        "Found a raw decrypt_value() call on a UserOAuthToken field — use "
+        "CredentialResolver._resolve_user_token_value() instead:\n" + "\n".join(violations)
+    )

--- a/api/tests/unit/controllers/test_oauth.py
+++ b/api/tests/unit/controllers/test_oauth.py
@@ -875,7 +875,14 @@ class TestUserTokens:
         assert "api token" in response.json()["detail"].lower()
 
     def test_save_api_token_create_success(self, authenticated_client):
-        """POST /user-tokens/api-token — creates new token; must not crash with tenant_id error."""
+        """POST /user-tokens/api-token — creates new token; must not crash with tenant_id error.
+
+        UserOAuthToken.access_token is an auto-encrypting property (see
+        src/models/user_oauth_token.py) — the endpoint must assign the raw plaintext
+        token directly and let the property encrypt it. Calling encrypt_value() first
+        (the original bug across every OAuth provider callback in this codebase) would
+        double-encrypt it, producing a token that never decrypts back to the original.
+        """
         test_client, mock_db, tenant_id, mock_account = authenticated_client
 
         mock_app = _create_mock_oauth_app(auth_method="api_token")
@@ -895,17 +902,24 @@ class TestUserTokens:
         mock_db.add = MagicMock()
         mock_db.commit = AsyncMock()
 
-        with patch("src.controllers.oauth.tokens.encrypt_value", return_value="encrypted"):
-            response = test_client.post(
-                "/api/v1/oauth/user-tokens/api-token",
-                json={"oauth_app_id": 1, "api_token": "mytoken"},
-            )
+        response = test_client.post(
+            "/api/v1/oauth/user-tokens/api-token",
+            json={"oauth_app_id": 1, "api_token": "mytoken"},
+        )
 
         assert response.status_code == status.HTTP_200_OK
         assert response.json()["success"] is True
+        # The UserOAuthToken passed to db.add() must carry the raw plaintext token —
+        # not something pre-encrypted by the endpoint itself.
+        added_token = mock_db.add.call_args.args[0]
+        assert added_token.access_token == "mytoken"
 
     def test_save_api_token_update_existing(self, authenticated_client):
-        """POST /user-tokens/api-token — updates existing token."""
+        """POST /user-tokens/api-token — updates existing token.
+
+        See test_save_api_token_create_success for why the assigned value must be the
+        raw plaintext, not an encrypt_value()-wrapped one.
+        """
         test_client, mock_db, tenant_id, mock_account = authenticated_client
 
         mock_app = _create_mock_oauth_app(auth_method="api_token")
@@ -923,15 +937,14 @@ class TestUserTokens:
         mock_db.execute = multi_execute
         mock_db.commit = AsyncMock()
 
-        with patch("src.controllers.oauth.tokens.encrypt_value", return_value="encrypted"):
-            response = test_client.post(
-                "/api/v1/oauth/user-tokens/api-token",
-                json={"oauth_app_id": 1, "api_token": "newtoken"},
-            )
+        response = test_client.post(
+            "/api/v1/oauth/user-tokens/api-token",
+            json={"oauth_app_id": 1, "api_token": "newtoken"},
+        )
 
         assert response.status_code == status.HTTP_200_OK
         assert response.json()["success"] is True
-        assert mock_existing_token.access_token == "encrypted"
+        assert mock_existing_token.access_token == "newtoken"
 
 
 class TestAuthorizeWithAuthenticatedUser:

--- a/api/tests/unit/services/agents/test_credential_resolver.py
+++ b/api/tests/unit/services/agents/test_credential_resolver.py
@@ -429,3 +429,87 @@ class TestGetJiraCredentials:
             credentials = await resolver.get_jira_credentials("internal_get_jira_issue")
 
         assert credentials is None
+
+
+class TestResolveUserTokenValue:
+    """Every OAuth provider callback (all 16 in src/controllers/oauth/) used to call
+    encrypt_value() before assigning to UserOAuthToken.access_token/.refresh_token — but
+    those are auto-encrypting properties, so this double-encrypted every personal OAuth
+    connection ever saved. Some read paths here also called decrypt_value() a second time
+    on top of the property's own decryption, which happened to cancel the double-encrypt
+    out by accident for those rows. Both write-side bugs are now fixed at the source, but
+    existing DB rows saved before the fix are still double-encrypted, so the read path
+    must keep working for both old (double-encrypted) and new (correctly single-encrypted)
+    rows without a data migration."""
+
+    def test_returns_plaintext_value_unchanged_when_not_further_encrypted(self):
+        """New rows: the property already decrypted once, giving real plaintext. A second
+        decrypt attempt must fail (it's not valid ciphertext) and the plaintext must be
+        returned as-is, not swallowed or corrupted."""
+        from src.services.agents.credential_resolver import CredentialResolver
+
+        plaintext = "glpat-realtoken1234567890"
+        assert CredentialResolver._resolve_user_token_value(plaintext) == plaintext
+
+    def test_unwraps_one_extra_layer_for_legacy_double_encrypted_rows(self):
+        """Legacy rows: the stored value was encrypt_value(encrypt_value(real)). The
+        property's own decryption already peels one layer by the time this helper sees
+        it, leaving one layer of ciphertext — this must unwrap that remaining layer and
+        return the original real plaintext."""
+        from src.services.agents.credential_resolver import CredentialResolver
+        from src.services.agents.security import encrypt_value
+
+        real_token = "glpat-realtoken1234567890"
+        # Simulates what the property getter hands back for a legacy double-encrypted
+        # row: one layer of encryption already stripped by the property, one left.
+        value_as_seen_by_helper = encrypt_value(real_token)
+
+        assert CredentialResolver._resolve_user_token_value(value_as_seen_by_helper) == real_token
+
+    def test_returns_none_for_none(self):
+        from src.services.agents.credential_resolver import CredentialResolver
+
+        assert CredentialResolver._resolve_user_token_value(None) is None
+
+
+class TestUserOAuthTokenRoundTrip:
+    """Integration-level proof against the real model + real encryption (not mocked) that
+    both the old buggy save path and the newly-fixed save path resolve to the same
+    plaintext via _get_user_token() — i.e. the fix doesn't require a data migration and
+    doesn't break access to tokens saved before it shipped."""
+
+    @pytest.mark.asyncio
+    async def test_get_user_token_resolves_both_legacy_and_fixed_rows(self, async_db_session, tenant, account):
+        from src.models.oauth_app import OAuthApp
+        from src.models.user_oauth_token import UserOAuthToken
+        from src.services.agents.security import encrypt_value
+
+        real_token_legacy = "glpat-legacy-real-token"
+        real_token_fixed = "glpat-fixed-real-token"
+
+        oauth_app_legacy = OAuthApp(tenant_id=tenant.id, provider="gitlab", app_name="legacy-app", auth_method="oauth")
+        oauth_app_fixed = OAuthApp(tenant_id=tenant.id, provider="gitlab", app_name="fixed-app", auth_method="oauth")
+        async_db_session.add_all([oauth_app_legacy, oauth_app_fixed])
+        await async_db_session.flush()
+
+        legacy_row = UserOAuthToken(account_id=account.id, oauth_app_id=oauth_app_legacy.id)
+        # Reproduces the old bug: encrypt_value() called before assigning to the
+        # auto-encrypting property, i.e. double-encrypted at rest.
+        legacy_row.access_token = encrypt_value(real_token_legacy)
+
+        fixed_row = UserOAuthToken(account_id=account.id, oauth_app_id=oauth_app_fixed.id)
+        # The fixed behavior: assign the real plaintext directly.
+        fixed_row.access_token = real_token_fixed
+
+        async_db_session.add_all([legacy_row, fixed_row])
+        await async_db_session.commit()
+
+        resolver_legacy = CredentialResolver(
+            RuntimeContext(tenant_id=tenant.id, agent_id=uuid.uuid4(), db_session=async_db_session, user_id=account.id)
+        )
+        resolver_fixed = CredentialResolver(
+            RuntimeContext(tenant_id=tenant.id, agent_id=uuid.uuid4(), db_session=async_db_session, user_id=account.id)
+        )
+
+        assert await resolver_legacy._get_user_token(oauth_app_legacy.id) == real_token_legacy
+        assert await resolver_fixed._get_user_token(oauth_app_fixed.id) == real_token_fixed

--- a/api/tests/unit/tasks/test_agent_tasks.py
+++ b/api/tests/unit/tasks/test_agent_tasks.py
@@ -441,12 +441,16 @@ class TestProcessWebhookEvent:
         assert sample_event.status == "completed"
         mock_db.close.assert_called_once()
 
+    @patch("src.core.database.reset_async_engine")
+    @patch("src.core.database.create_celery_async_session")
     @patch("src.services.agents.chat_stream_service.ChatStreamService.stream_agent_response")
     @patch("src.tasks.agent_tasks.SessionLocal")
     def test_process_webhook_event_message_formatting(
         self,
         mock_session_local,
         mock_stream_agent,
+        mock_create_async_session,
+        mock_reset_engine,
         mock_db,
         sample_webhook,
         sample_event,
@@ -469,6 +473,13 @@ class TestProcessWebhookEvent:
 
         mock_db.query.side_effect = [webhook_query, event_query, agent_query]
 
+        # Mock async session used inside process_agent() for Conversation creation —
+        # without this, a real INSERT runs against the test DB with sample_agent's
+        # fake uuid4() id, which no Agent row backs, and fails on the FK constraint.
+        mock_create, _ = _make_async_session_mock()
+        mock_create_async_session.side_effect = mock_create.side_effect
+        mock_create_async_session.return_value = mock_create.return_value
+
         async def mock_agent_stream(*args, **kwargs):
             yield "data: " + json.dumps({"type": "chunk", "content": "OK"})
 
@@ -482,12 +493,16 @@ class TestProcessWebhookEvent:
 
         mock_db.close.assert_called_once()
 
+    @patch("src.core.database.reset_async_engine")
+    @patch("src.core.database.create_celery_async_session")
     @patch("src.services.agents.chat_stream_service.ChatStreamService.stream_agent_response")
     @patch("src.tasks.agent_tasks.SessionLocal")
     def test_process_webhook_event_response_truncation(
         self,
         mock_session_local,
         mock_stream_agent,
+        mock_create_async_session,
+        mock_reset_engine,
         mock_db,
         sample_webhook,
         sample_event,
@@ -509,6 +524,12 @@ class TestProcessWebhookEvent:
         agent_query.filter.return_value.first.return_value = sample_agent
 
         mock_db.query.side_effect = [webhook_query, event_query, agent_query]
+
+        # Mock async session used inside process_agent() for Conversation creation —
+        # see comment in test_process_webhook_event_message_formatting.
+        mock_create, _ = _make_async_session_mock()
+        mock_create_async_session.side_effect = mock_create.side_effect
+        mock_create_async_session.return_value = mock_create.return_value
 
         long_content = "A" * 6000
 


### PR DESCRIPTION
## Summary
Root cause for "reauthenticate GitLab, still throws auth error" — traced end-to-end, not guessed:

**Every personal ("connect my own account") OAuth token save across the entire platform has been double-encrypted, for every provider, since this pattern was introduced.** `UserOAuthToken.access_token`/`.refresh_token` (`src/models/user_oauth_token.py`) are auto-encrypting Python properties, but every single OAuth callback controller called `encrypt_value()` before assigning to them — encrypting on top of the property's own encryption.

This went unnoticed because `credential_resolver.py`'s read paths mostly called `decrypt_value()` a second time on top of the property's own decryption — an equal-and-opposite bug that happened to cancel the double-encryption out for existing rows. An earlier commit on this same investigation (already merged) fixed only `gitlab.py`'s write side, which is what surfaced this: the read path stayed unfixed, so it only ever undid one of the two layers, producing a still-encrypted string that "looked like" a token to a mock but got a real 401 from GitLab.

## Fix
Both sides fixed together, across all 16 providers (clickup, github, gitlab, google ×3 — calendar/drive/gmail, hubspot, intercom, jira, linkedin, micromobility, salesforce, slack, tokens.py, twitter, zendesk, zoho, zoom):
- **Write side**: every controller now assigns the raw plaintext token directly; the property encrypts it. (`OAuthApp.access_token`/`refresh_token` are plain, non-encrypting columns, so those app-level assignments correctly keep their explicit `encrypt_value()` call — unchanged.)
- **Read side**: added `CredentialResolver._resolve_user_token_value()` — a self-healing helper that tries one more decrypt on top of the property's own decryption. Legacy double-encrypted rows unwrap correctly; already-plaintext (correctly-saved) rows are returned as-is when the extra decrypt attempt fails. Replaced 11 call sites (github/zoom/google calendar/google drive/twitter/linkedin) that called `decrypt_value()` directly, and fixed the matching write-side double-encrypt-on-refresh bug in zoom/google calendar/google drive/twitter/linkedin.

**No data migration needed** — the read-side fix transparently handles both old and new rows.

**Security note**: this does not change what's exposed to an LLM. `CredentialResolver` only ever returns decrypted tokens to server-side tool-execution code (e.g. `gitlab_tools.py`'s HTTP client), never to agent/LLM context — that boundary is untouched.

## Test plan
- [x] Fixed `tests/unit/controllers/test_oauth.py::TestUserTokens::test_save_api_token_update_existing` — it was the *only* test in the whole suite, and it explicitly asserted the buggy double-encrypted value as correct.
- [x] Added `tests/unit/controllers/oauth/test_user_oauth_token_no_double_encryption.py` — static source-level regression guard across all 16 controllers *and* `credential_resolver.py` (a DB/mock test can't catch this class of bug; double-encrypted values still look valid to a mock).
- [x] Added unit + integration tests for `_resolve_user_token_value` in `test_credential_resolver.py`, including a real-model + real-encryption round trip proving both a legacy double-encrypted row and a correctly-saved row resolve to the same plaintext.
- [x] Full `tests/unit/` suite: 4135 passed via `docker-compose exec api pytest`. Two tests failed only in the full batch run and passed cleanly in isolation (pre-existing flakiness, unrelated); all other failures trace to a pre-existing `pypdf`-missing-in-container gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)